### PR TITLE
🔥 v2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mocha-jenkins-reporter": "0.3.12",
     "moment": "2.22.2",
     "platform-folders": "0.2.7",
-    "sequelize": "4.38.0",
+    "sequelize": "4.38.1",
     "should": "13.1.3",
     "sqlite3": "4.0.2",
     "tsconfig": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mocha-jenkins-reporter": "0.3.12",
     "moment": "2.22.2",
     "platform-folders": "0.2.7",
-    "sequelize": "4.38.1",
+    "sequelize": "4.38.0",
     "should": "13.1.3",
     "sqlite3": "4.0.2",
     "tsconfig": "7.0.0",


### PR DESCRIPTION
**Changes:**

1. Remove unique-constraint from flowNodeInstanceId

Due to a bug within sequelize, we cannot set unique constraints at the moment. This has the effect of rendering foreignKeys unusable, because most DBs won't allow for non-uniqe fields to be used as foreignKey index.
Until this is fixed, the unique-constraint is removed from flowNodeInstanceId.
Since we are auto-generating these anyway, this shouldn't lead to any serious problems.


**Issues:**

Closes #57 

PR: #58

## How can others test the changes?

Run the migrations.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️     |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️     |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
