### PR TITLE
✨ Add a Response when the User accesses the Root Route

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,10 +78,12 @@ async function startProcessEngine(sqlitePath) {
 
     const httpExtension = await container.resolveAsync('HttpExtension');
     httpExtension.app.get('/', (request, response) => {
-      const name = packageJson.name;
-      const version = packageJson.version;
-      const license = packageJson.license;
-      const contributors = packageJson.contributors;
+      const {
+        name,
+        version,
+        license,
+        contributors,
+      } = packageJson;
 
       const returnObject = {
         name: name,

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const fs = require('fs');
 const Logger = require('loggerhythm').Logger;
 const path = require('path');
 const platformFolders = require('platform-folders');
+const packageJson = require('./package.json');
 
 Bluebird.config({
   cancellation: true,
@@ -74,6 +75,27 @@ async function startProcessEngine(sqlitePath) {
     await bootstrapper.start();
 
     logger.info('Bootstrapper started successfully.');
+
+    const httpExtension = await container.resolveAsync('HttpExtension');
+    httpExtension.app.get('/', (request, response) => {
+      const name = packageJson.name;
+      const version = packageJson.version;
+      const license = packageJson.license;
+      const contributors = packageJson.contributors;
+
+      const returnObject = {
+        name: name,
+        version: version,
+        license: license,
+        contributors: contributors,
+      };
+
+      response
+        .status(200)
+        .header('Content-Type', 'application/json')
+        .send(JSON.stringify(returnObject, null, 2));
+    });
+
   } catch (error) {
     logger.error('Bootstrapper failed to start.', error);
   }


### PR DESCRIPTION
**Changes:**

1. Adds a response when the user tries to access the route route of a running ProcessEngine instance.

The answer returns some properties from the `package.json` such as: 
* The application name
* The current running version
* The license
* The contriburots


**Issues:**

Closes #201 

PR: #211

## How can others test the changes?

Start the application and access `localhost:8000`.
You should no longer receive `Cannot GET /`, but a formatted JSON that contains the properties listed above.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).