### PR TITLE
✨ Add validations for ProcessModel persistence

### DIFF
--- a/bpmn/process_model_name_mismatch.bpmn
+++ b/bpmn/process_model_name_mismatch.bpmn
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_15mlx3e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
+  <bpmn:collaboration id="Collaboration_0bxb8mu">
+    <bpmn:participant id="Participant_0ylnmok" name="process_model_name_mismatch_part_2" processRef="process_model_name_mismatch_part_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_model_name_mismatch_part_2" name="process_model_name_mismatch_part_2" isExecutable="true" camunda:versionTag="1.0">
+    <bpmn:laneSet id="LaneSet_08i1la7" />
+    <bpmn:startEvent id="startEvent" name="Start" camunda:formKey="TradeId">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="FormField_0go8uv1" label="test" type="long" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_0coq1aw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0coq1aw" sourceRef="startEvent" targetRef="Task_1a5ko2x" />
+    <bpmn:sequenceFlow id="SequenceFlow_0ya4kwj" sourceRef="Task_0a8vuqp" targetRef="ExclusiveGateway_17rh46l" />
+    <bpmn:sequenceFlow id="SequenceFlow_08ip971" sourceRef="Task_1dejorx" targetRef="ExclusiveGateway_17rh46l" />
+    <bpmn:sequenceFlow id="SequenceFlow_003v0e4" sourceRef="ExclusiveGateway_1khwy6z" targetRef="Task_0a8vuqp" />
+    <bpmn:sequenceFlow id="SequenceFlow_1jlkayj" sourceRef="ExclusiveGateway_1khwy6z" targetRef="Task_1dejorx" />
+    <bpmn:sequenceFlow id="SequenceFlow_0581wvt" sourceRef="Task_1a5ko2x" targetRef="ExclusiveGateway_1khwy6z" />
+    <bpmn:sequenceFlow id="SequenceFlow_1xxn53i" sourceRef="ExclusiveGateway_17rh46l" targetRef="EndEvent_1fffh59" />
+    <bpmn:sequenceFlow id="SequenceFlow_1kelad1" sourceRef="Task_1234" targetRef="ExclusiveGateway_17rh46l" />
+    <bpmn:sequenceFlow id="SequenceFlow_0nchi8x" sourceRef="ExclusiveGateway_1khwy6z" targetRef="Task_1234" />
+    <bpmn:serviceTask id="Task_0a8vuqp" name="Update pricing event dates" camunda:type="external" camunda:topic="Terra.Valuation.UpdatePricingEventDatesForTrade">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_003v0e4</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0ya4kwj</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_1dejorx" name="Update settlement dates" camunda:type="external" camunda:topic="Terra.Settlement.UpdateSettlementDatesForTrade">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1jlkayj</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_08ip971</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:parallelGateway id="ExclusiveGateway_17rh46l">
+      <bpmn:incoming>SequenceFlow_1kelad1</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_08ip971</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0ya4kwj</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1xxn53i</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="ExclusiveGateway_1khwy6z">
+      <bpmn:incoming>SequenceFlow_0581wvt</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0nchi8x</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1jlkayj</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_003v0e4</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_1fffh59" name="End">
+      <bpmn:incoming>SequenceFlow_1xxn53i</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="Task_1234" name="Update payment due dates" camunda:type="external" camunda:topic="Terra.Settlement.UpdatePaymentDueDatesForTrade">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0nchi8x</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1kelad1</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_1a5ko2x" name="Update unscheduled quantities" camunda:type="external" camunda:topic="Terra.Scheduling.UpdateUnscheduledQuantitiesForTrade">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0coq1aw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0581wvt</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0bxb8mu">
+      <bpmndi:BPMNShape id="Participant_0ylnmok_di" bpmnElement="Participant_0ylnmok">
+        <dc:Bounds x="109" y="69" width="893" height="390" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0mnj5km_di" bpmnElement="Task_1234">
+        <dc:Bounds x="615" y="102" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_10ithzc_di" bpmnElement="startEvent">
+        <dc:Bounds x="161" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="167" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1fffh59_di" bpmnElement="EndEvent_1fffh59">
+        <dc:Bounds x="942" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="950" y="167" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0coq1aw_di" bpmnElement="SequenceFlow_0coq1aw">
+        <di:waypoint x="197" y="142" />
+        <di:waypoint x="283" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0581wvt_di" bpmnElement="SequenceFlow_0581wvt">
+        <di:waypoint x="383" y="142" />
+        <di:waypoint x="474" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ParallelGateway_0b7ur9p_di" bpmnElement="ExclusiveGateway_1khwy6z">
+        <dc:Bounds x="474" y="117" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0nchi8x_di" bpmnElement="SequenceFlow_0nchi8x">
+        <di:waypoint x="524" y="142" />
+        <di:waypoint x="615" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kelad1_di" bpmnElement="SequenceFlow_1kelad1">
+        <di:waypoint x="715" y="142" />
+        <di:waypoint x="806" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1xxn53i_di" bpmnElement="SequenceFlow_1xxn53i">
+        <di:waypoint x="856" y="142" />
+        <di:waypoint x="942" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ParallelGateway_1gywxjy_di" bpmnElement="ExclusiveGateway_17rh46l">
+        <dc:Bounds x="806" y="117" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jlkayj_di" bpmnElement="SequenceFlow_1jlkayj">
+        <di:waypoint x="499" y="167" />
+        <di:waypoint x="499" y="265" />
+        <di:waypoint x="615" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_08ip971_di" bpmnElement="SequenceFlow_08ip971">
+        <di:waypoint x="715" y="265" />
+        <di:waypoint x="831" y="265" />
+        <di:waypoint x="831" y="167" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_003v0e4_di" bpmnElement="SequenceFlow_003v0e4">
+        <di:waypoint x="499" y="167" />
+        <di:waypoint x="499" y="387" />
+        <di:waypoint x="615" y="387" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ya4kwj_di" bpmnElement="SequenceFlow_0ya4kwj">
+        <di:waypoint x="715" y="387" />
+        <di:waypoint x="831" y="387" />
+        <di:waypoint x="831" y="167" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_029o80s_di" bpmnElement="Task_1dejorx">
+        <dc:Bounds x="615" y="225" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1oo84a2_di" bpmnElement="Task_0a8vuqp">
+        <dc:Bounds x="615" y="347" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0gz0aa3_di" bpmnElement="Task_1a5ko2x">
+        <dc:Bounds x="283" y="102" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/bpmn/process_model_name_mismatch.bpmn
+++ b/bpmn/process_model_name_mismatch.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_15mlx3e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_15mlx3e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
   <bpmn:collaboration id="Collaboration_0bxb8mu">
     <bpmn:participant id="Participant_0ylnmok" name="process_model_name_mismatch_part_2" processRef="process_model_name_mismatch_part_2" />
   </bpmn:collaboration>
@@ -14,66 +14,11 @@
       <bpmn:outgoing>SequenceFlow_0coq1aw</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0coq1aw" sourceRef="startEvent" targetRef="Task_1a5ko2x" />
-    <bpmn:sequenceFlow id="SequenceFlow_0ya4kwj" sourceRef="Task_0a8vuqp" targetRef="ExclusiveGateway_17rh46l" />
-    <bpmn:sequenceFlow id="SequenceFlow_08ip971" sourceRef="Task_1dejorx" targetRef="ExclusiveGateway_17rh46l" />
-    <bpmn:sequenceFlow id="SequenceFlow_003v0e4" sourceRef="ExclusiveGateway_1khwy6z" targetRef="Task_0a8vuqp" />
-    <bpmn:sequenceFlow id="SequenceFlow_1jlkayj" sourceRef="ExclusiveGateway_1khwy6z" targetRef="Task_1dejorx" />
-    <bpmn:sequenceFlow id="SequenceFlow_0581wvt" sourceRef="Task_1a5ko2x" targetRef="ExclusiveGateway_1khwy6z" />
-    <bpmn:sequenceFlow id="SequenceFlow_1xxn53i" sourceRef="ExclusiveGateway_17rh46l" targetRef="EndEvent_1fffh59" />
-    <bpmn:sequenceFlow id="SequenceFlow_1kelad1" sourceRef="Task_1234" targetRef="ExclusiveGateway_17rh46l" />
-    <bpmn:sequenceFlow id="SequenceFlow_0nchi8x" sourceRef="ExclusiveGateway_1khwy6z" targetRef="Task_1234" />
-    <bpmn:serviceTask id="Task_0a8vuqp" name="Update pricing event dates" camunda:type="external" camunda:topic="Terra.Valuation.UpdatePricingEventDatesForTrade">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
-        </camunda:inputOutput>
-        <camunda:properties>
-          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
-        </camunda:properties>
-      </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_003v0e4</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0ya4kwj</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="Task_1dejorx" name="Update settlement dates" camunda:type="external" camunda:topic="Terra.Settlement.UpdateSettlementDatesForTrade">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
-        </camunda:inputOutput>
-        <camunda:properties>
-          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
-        </camunda:properties>
-      </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_1jlkayj</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_08ip971</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:parallelGateway id="ExclusiveGateway_17rh46l">
-      <bpmn:incoming>SequenceFlow_1kelad1</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_08ip971</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_0ya4kwj</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1xxn53i</bpmn:outgoing>
-    </bpmn:parallelGateway>
-    <bpmn:parallelGateway id="ExclusiveGateway_1khwy6z">
-      <bpmn:incoming>SequenceFlow_0581wvt</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0nchi8x</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_1jlkayj</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_003v0e4</bpmn:outgoing>
-    </bpmn:parallelGateway>
     <bpmn:endEvent id="EndEvent_1fffh59" name="End">
-      <bpmn:incoming>SequenceFlow_1xxn53i</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0dlf4pr</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:serviceTask id="Task_1234" name="Update payment due dates" camunda:type="external" camunda:topic="Terra.Settlement.UpdatePaymentDueDatesForTrade">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
-        </camunda:inputOutput>
-        <camunda:properties>
-          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
-        </camunda:properties>
-      </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_0nchi8x</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1kelad1</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="Task_1a5ko2x" name="Update unscheduled quantities" camunda:type="external" camunda:topic="Terra.Scheduling.UpdateUnscheduledQuantitiesForTrade">
+    <bpmn:sequenceFlow id="SequenceFlow_0dlf4pr" sourceRef="Task_1a5ko2x" targetRef="EndEvent_1fffh59" />
+    <bpmn:scriptTask id="Task_1a5ko2x" name="Do stuff">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
@@ -83,16 +28,14 @@
         </camunda:properties>
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0coq1aw</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0581wvt</bpmn:outgoing>
-    </bpmn:serviceTask>
+      <bpmn:outgoing>SequenceFlow_0dlf4pr</bpmn:outgoing>
+      <bpmn:script>return 'I am a Wookie!';</bpmn:script>
+    </bpmn:scriptTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0bxb8mu">
       <bpmndi:BPMNShape id="Participant_0ylnmok_di" bpmnElement="Participant_0ylnmok">
-        <dc:Bounds x="109" y="69" width="893" height="390" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0mnj5km_di" bpmnElement="Task_1234">
-        <dc:Bounds x="615" y="102" width="100" height="80" />
+        <dc:Bounds x="109" y="69" width="517" height="195" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="StartEvent_10ithzc_di" bpmnElement="startEvent">
         <dc:Bounds x="161" y="124" width="36" height="36" />
@@ -101,64 +44,20 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1fffh59_di" bpmnElement="EndEvent_1fffh59">
-        <dc:Bounds x="942" y="124" width="36" height="36" />
+        <dc:Bounds x="548" y="124" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="950" y="167" width="20" height="14" />
+          <dc:Bounds x="556" y="167" width="20" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0coq1aw_di" bpmnElement="SequenceFlow_0coq1aw">
         <di:waypoint x="197" y="142" />
         <di:waypoint x="283" y="142" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0581wvt_di" bpmnElement="SequenceFlow_0581wvt">
+      <bpmndi:BPMNEdge id="SequenceFlow_0dlf4pr_di" bpmnElement="SequenceFlow_0dlf4pr">
         <di:waypoint x="383" y="142" />
-        <di:waypoint x="474" y="142" />
+        <di:waypoint x="548" y="142" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ParallelGateway_0b7ur9p_di" bpmnElement="ExclusiveGateway_1khwy6z">
-        <dc:Bounds x="474" y="117" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0nchi8x_di" bpmnElement="SequenceFlow_0nchi8x">
-        <di:waypoint x="524" y="142" />
-        <di:waypoint x="615" y="142" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1kelad1_di" bpmnElement="SequenceFlow_1kelad1">
-        <di:waypoint x="715" y="142" />
-        <di:waypoint x="806" y="142" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1xxn53i_di" bpmnElement="SequenceFlow_1xxn53i">
-        <di:waypoint x="856" y="142" />
-        <di:waypoint x="942" y="142" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ParallelGateway_1gywxjy_di" bpmnElement="ExclusiveGateway_17rh46l">
-        <dc:Bounds x="806" y="117" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1jlkayj_di" bpmnElement="SequenceFlow_1jlkayj">
-        <di:waypoint x="499" y="167" />
-        <di:waypoint x="499" y="265" />
-        <di:waypoint x="615" y="265" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_08ip971_di" bpmnElement="SequenceFlow_08ip971">
-        <di:waypoint x="715" y="265" />
-        <di:waypoint x="831" y="265" />
-        <di:waypoint x="831" y="167" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_003v0e4_di" bpmnElement="SequenceFlow_003v0e4">
-        <di:waypoint x="499" y="167" />
-        <di:waypoint x="499" y="387" />
-        <di:waypoint x="615" y="387" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ya4kwj_di" bpmnElement="SequenceFlow_0ya4kwj">
-        <di:waypoint x="715" y="387" />
-        <di:waypoint x="831" y="387" />
-        <di:waypoint x="831" y="167" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ServiceTask_029o80s_di" bpmnElement="Task_1dejorx">
-        <dc:Bounds x="615" y="225" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1oo84a2_di" bpmnElement="Task_0a8vuqp">
-        <dc:Bounds x="615" y="347" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0gz0aa3_di" bpmnElement="Task_1a5ko2x">
+      <bpmndi:BPMNShape id="ScriptTask_1iodeif_di" bpmnElement="Task_1a5ko2x">
         <dc:Bounds x="283" y="102" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/bpmn/process_model_too_many_processes.bpmn
+++ b/bpmn/process_model_too_many_processes.bpmn
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_15mlx3e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
+  <bpmn:collaboration id="Collaboration_0bxb8mu">
+    <bpmn:participant id="Participant_0ylnmok" name="process_model_too_many_processes" processRef="process_model_too_many_processes" />
+    <bpmn:participant id="Participant_1cr6h77" name="hello_hello" processRef="Process_0tfbmod" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_model_too_many_processes" name="process_model_too_many_processes" isExecutable="true" camunda:versionTag="1.0">
+    <bpmn:laneSet id="LaneSet_08i1la7" />
+    <bpmn:startEvent id="startEvent" name="Start" camunda:formKey="TradeId">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="FormField_0go8uv1" label="test" type="long" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_0coq1aw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0coq1aw" sourceRef="startEvent" targetRef="Task_1a5ko2x" />
+    <bpmn:sequenceFlow id="SequenceFlow_0eaztre" sourceRef="Task_1a5ko2x" targetRef="EndEvent_1fffh59" />
+    <bpmn:endEvent id="EndEvent_1fffh59" name="End">
+      <bpmn:incoming>SequenceFlow_0eaztre</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:scriptTask id="Task_1a5ko2x" name="Do stuff">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="TradeId">${TradeId}</camunda:inputParameter>
+        </camunda:inputOutput>
+        <camunda:properties>
+          <camunda:property name="payload" value="{&#10;  tradeId: token.history.startEvent.tradeId&#10;}" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0coq1aw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0eaztre</bpmn:outgoing>
+      <bpmn:script>return 'hello hello';</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmn:process id="Process_0tfbmod" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_04wcb4s" name="Start 2">
+      <bpmn:outgoing>SequenceFlow_1b04ayn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1b04ayn" sourceRef="StartEvent_04wcb4s" targetRef="Task_1om4n2x" />
+    <bpmn:endEvent id="EndEvent_1626zcb" name="End 2">
+      <bpmn:incoming>SequenceFlow_0hbnkei</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0hbnkei" sourceRef="Task_1om4n2x" targetRef="EndEvent_1626zcb" />
+    <bpmn:scriptTask id="Task_1om4n2x" name="Do other stuff">
+      <bpmn:incoming>SequenceFlow_1b04ayn</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0hbnkei</bpmn:outgoing>
+      <bpmn:script>return '';</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0bxb8mu">
+      <bpmndi:BPMNShape id="Participant_0ylnmok_di" bpmnElement="Participant_0ylnmok">
+        <dc:Bounds x="109" y="69" width="542" height="220" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_10ithzc_di" bpmnElement="startEvent">
+        <dc:Bounds x="161" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="168" y="167" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1fffh59_di" bpmnElement="EndEvent_1fffh59">
+        <dc:Bounds x="490" y="124" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="498" y="167" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0coq1aw_di" bpmnElement="SequenceFlow_0coq1aw">
+        <di:waypoint x="197" y="142" />
+        <di:waypoint x="283" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_1cr6h77_di" bpmnElement="Participant_1cr6h77">
+        <dc:Bounds x="109" y="347" width="540" height="197" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0eaztre_di" bpmnElement="SequenceFlow_0eaztre">
+        <di:waypoint x="383" y="142" />
+        <di:waypoint x="490" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0eicgk5_di" bpmnElement="Task_1a5ko2x">
+        <dc:Bounds x="283" y="102" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_04wcb4s_di" bpmnElement="StartEvent_04wcb4s">
+        <dc:Bounds x="165" y="439" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="167" y="482" width="33" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1b04ayn_di" bpmnElement="SequenceFlow_1b04ayn">
+        <di:waypoint x="201" y="457" />
+        <di:waypoint x="297" y="457" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1626zcb_di" bpmnElement="EndEvent_1626zcb">
+        <dc:Bounds x="525" y="439" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="529" y="482" width="29" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hbnkei_di" bpmnElement="SequenceFlow_0hbnkei">
+        <di:waypoint x="397" y="457" />
+        <di:waypoint x="525" y="457" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0ar8k7j_di" bpmnElement="Task_1om4n2x">
+        <dc:Bounds x="297" y="417" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,9 +1221,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "8.7.3-80150539-b2",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-8.7.3-80150539-b2.tgz",
-      "integrity": "sha512-bux9oK6ZtxWcWjcIcAAA6WnRB6OAXe3JYA7qr5DLrS/DM5pGqCWRtb2+vkWDPAXTVfpBBLrSPFqmI2QW2Cc09Q==",
+      "version": "8.7.4",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-8.7.4.tgz",
+      "integrity": "sha512-rGM4PIrK0EdBnG+n58m1e5mUBN6oGTVPs0gqbKZHaxVtm1lrh5VHtjkpFgF6tQFMvza7XCTVk4OKyO4tfuS5FA==",
       "requires": {
         "@essential-projects/errors_ts": "~1.4.0",
         "@essential-projects/event_aggregator_contracts": "~4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,9 +1221,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-8.7.3.tgz",
-      "integrity": "sha512-0tltwUVoWpDfYbsTB37cYdgS4v9qvzIQ+X1JHoRCahTFe5dDArzPM1Q7FJ50aaS8wcNQOKrWFl5jJ2eUYw9SAA==",
+      "version": "8.7.3-80150539-b2",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-8.7.3-80150539-b2.tgz",
+      "integrity": "sha512-bux9oK6ZtxWcWjcIcAAA6WnRB6OAXe3JYA7qr5DLrS/DM5pGqCWRtb2+vkWDPAXTVfpBBLrSPFqmI2QW2Cc09Q==",
       "requires": {
         "@essential-projects/errors_ts": "~1.4.0",
         "@essential-projects/event_aggregator_contracts": "~4.0.0",
@@ -3424,9 +3424,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
-      "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
+      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4633,13 +4633,33 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
-      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
+      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@process-engine/management_api_http": "2.0.0",
     "@process-engine/metrics_api_core": "1.0.0",
     "@process-engine/metrics.repository.file_system": "1.1.0",
-    "@process-engine/process_engine_core": "8.7.3",
+    "@process-engine/process_engine_core": "feature~add_process_model_persistence_validations",
     "@process-engine/process_model.repository.sequelize": "4.2.1",
     "@process-engine/token_history_api_http": "1.3.1",
     "@process-engine/token_history_api_core": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@process-engine/management_api_http": "2.0.0",
     "@process-engine/metrics_api_core": "1.0.0",
     "@process-engine/metrics.repository.file_system": "1.1.0",
-    "@process-engine/process_engine_core": "feature~add_process_model_persistence_validations",
+    "@process-engine/process_engine_core": "8.7.4",
     "@process-engine/process_model.repository.sequelize": "4.2.1",
     "@process-engine/token_history_api_http": "1.3.1",
     "@process-engine/token_history_api_core": "1.3.2",

--- a/test/2_management_api/process_models/update_process_definitions_by_name.js
+++ b/test/2_management_api/process_models/update_process_definitions_by_name.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const should = require('should');
-const uuid = require('uuid');
 
 const TestFixtureProvider = require('../../../dist/commonjs').TestFixtureProvider;
 
@@ -28,9 +27,6 @@ describe('Management API:   POST  ->  /process_models/:process_model_id/update',
 
   it('should successfully import the process definitions, if it does not yet exist and overwriteExisting is set to false', async () => {
 
-    // This is to ensure that any existing process definitions will not falsify the results.
-    const uniqueImportName = uuid.v4();
-
     const importPayload = {
       xml: processModelAsXml,
       overwriteExisting: true,
@@ -38,7 +34,7 @@ describe('Management API:   POST  ->  /process_models/:process_model_id/update',
 
     await testFixtureProvider
       .managementApiClientService
-      .updateProcessDefinitionsByName(testFixtureProvider.identities.defaultUser, uniqueImportName, importPayload);
+      .updateProcessDefinitionsByName(testFixtureProvider.identities.defaultUser, processModelId, importPayload);
 
     await assertThatImportWasSuccessful();
   });

--- a/test/4_deployment_api/import_from_file.js
+++ b/test/4_deployment_api/import_from_file.js
@@ -106,7 +106,7 @@ describe('Deployment API -> importBpmnFromFile', () => {
         .deploymentApiService
         .importBpmnFromFile(defaultIdentity, processModelPathNameMismatch, processModelIdNameMismatch);
 
-      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+      should.fail(undefined, 'error', 'This request should have failed, because ProcessModel name differs from the ProcessDefinitions name!');
     } catch (error) {
       const expectedErrorMessage = /ProcessModel contained within the diagram.*?must also use the name/i;
       const expectedErrorCode = 422;

--- a/test/4_deployment_api/import_from_file.js
+++ b/test/4_deployment_api/import_from_file.js
@@ -2,7 +2,6 @@
 
 const should = require('should');
 const path = require('path');
-const uuid = require('uuid');
 
 const TestFixtureProvider = require('../../dist/commonjs').TestFixtureProvider;
 
@@ -14,8 +13,13 @@ describe('Deployment API -> importBpmnFromFile', () => {
 
   const processModelId = 'generic_sample';
   const processModelIdNoLanes = 'process_model_without_lanes';
+  const processModelIdNameMismatch = 'process_model_name_mismatch';
+  const processModelIdTooManyProcesses = 'process_model_too_many_processes';
+
   let processModelPath;
   let processModelPathNoLanes;
+  let processModelPathNameMismatch;
+  let processModelPathTooManyProcesses;
 
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
@@ -25,33 +29,19 @@ describe('Deployment API -> importBpmnFromFile', () => {
     restrictedIdentity = testFixtureProvider.identities.restrictedUser;
 
     const bpmnFolderLocation = testFixtureProvider.getBpmnDirectoryPath();
+
     processModelPath = path.join(bpmnFolderLocation, `${processModelId}.bpmn`);
     processModelPathNoLanes = path.join(bpmnFolderLocation, `${processModelIdNoLanes}.bpmn`);
+    processModelPathNameMismatch = path.join(bpmnFolderLocation, `${processModelIdNameMismatch}.bpmn`);
+    processModelPathTooManyProcesses = path.join(bpmnFolderLocation, `${processModelIdTooManyProcesses}.bpmn`);
   });
 
   after(async () => {
     await testFixtureProvider.tearDown();
   });
 
-  it('should successfully import a ProcessModel, if it does not yet exist and overwriteExisting is set to false', async () => {
-
-    // This is to ensure that any existing process models will not falsify the results.
-    const uniqueImportName = uuid.v4();
-
-    await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, uniqueImportName, false);
-
-    await assertThatImportWasSuccessful();
-  });
-
-  it('should successfully import a ProcessModel, if it already exists and overwriteExisting is set to true', async () => {
-
-    // This is to ensure that any existing process models will not falsify the results.
-    const uniqueImportName = uuid.v4();
-
-    // The value of overwriteExisting doesn't matter for the first import run.
-    await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, uniqueImportName);
-    await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, uniqueImportName, true);
-
+  it('should successfully import a ProcessModel', async () => {
+    await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, processModelId, true);
     await assertThatImportWasSuccessful();
   });
 
@@ -68,13 +58,9 @@ describe('Deployment API -> importBpmnFromFile', () => {
   it('should fail to import a ProcessModel, if a process model by the same name exists, and overwriteExisting is set to false', async () => {
 
     try {
-
-      // This is to ensure that any existing process models will not falsify the results.
-      const uniqueImportName = uuid.v4();
-
-      // The value of overwriteExisting doesn't matter for the first import run.
-      await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, uniqueImportName);
-      await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, uniqueImportName, false);
+      // Run this twice to ensure that this test case is always executable.
+      await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, processModelId, false);
+      await testFixtureProvider.deploymentApiService.importBpmnFromFile(defaultIdentity, processModelPath, processModelId, false);
 
       should.fail(undefined, 'error', 'This request should have failed, because a ProcessModel already exists!');
     } catch (error) {
@@ -83,7 +69,6 @@ describe('Deployment API -> importBpmnFromFile', () => {
       should(error.code).be.eql(expectedErrorCode);
       should(error.message).be.match(expectedErrorMessage);
     }
-
   });
 
   it('should fail to import a ProcessModel, when the user is not authenticated', async () => {
@@ -109,6 +94,43 @@ describe('Deployment API -> importBpmnFromFile', () => {
       const expectedErrorMessage = /access denied/i;
       should(error.code).be.eql(expectedErrorCode);
       should(error.message).be.match(expectedErrorMessage);
+    }
+  });
+
+  // Note: Current restrictions state that a ProcessModel must have the same name as the Definition file.
+  // Otherwise the ProcessModel would not be retrievable.
+  it('should fail to import a ProcessModel, when the ProcessModel name does not match the ProcessDefinition name', async () => {
+
+    try {
+      await testFixtureProvider
+        .deploymentApiService
+        .importBpmnFromFile(defaultIdentity, processModelPathNameMismatch, processModelIdNameMismatch);
+
+      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+    } catch (error) {
+      const expectedErrorMessage = /ProcessModel contained within the diagram.*?must also use the name/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
+    }
+  });
+
+  // Note: This may be supported in future versions, but right now such a BPMN file would break everything.
+  // So we need to make sure that those types of ProcessModels do not get deployed.
+  // Otherwise, BPMN Studio will be unable to use the Runtime at all.
+  it('should fail to import a ProcessModel, when the file contains more than one Process', async () => {
+
+    try {
+      await testFixtureProvider
+        .deploymentApiService
+        .importBpmnFromFile(defaultIdentity, processModelPathTooManyProcesses, processModelIdTooManyProcesses);
+
+      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+    } catch (error) {
+      const expectedErrorMessage = /contains more than one ProcessModel/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
     }
   });
 

--- a/test/4_deployment_api/import_from_xml_local.js
+++ b/test/4_deployment_api/import_from_xml_local.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const should = require('should');
-const uuid = require('uuid');
 
 const TestFixtureProvider = require('../../dist/commonjs').TestFixtureProvider;
 
@@ -13,8 +12,13 @@ describe('Deployment API -> importBpmnFromXml', () => {
 
   const processModelId = 'generic_sample';
   const processModelIdNoLanes = 'process_model_without_lanes';
+  const processModelIdNameMismatch = 'process_model_name_mismatch';
+  const processModelIdTooManyProcesses = 'process_model_too_many_processes';
+
   let processModelAsXml;
   let processModelNoLanesAsXml;
+  let processModelPathNameMismatchAsXml;
+  let processModelPathTooManyProcessesAsXml;
 
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
@@ -25,43 +29,23 @@ describe('Deployment API -> importBpmnFromXml', () => {
 
     processModelAsXml = testFixtureProvider.readProcessModelFile(processModelId);
     processModelNoLanesAsXml = testFixtureProvider.readProcessModelFile(processModelIdNoLanes);
+    processModelPathNameMismatchAsXml = testFixtureProvider.readProcessModelFile(processModelIdNameMismatch);
+    processModelPathTooManyProcessesAsXml = testFixtureProvider.readProcessModelFile(processModelIdTooManyProcesses);
   });
 
   after(async () => {
     await testFixtureProvider.tearDown();
   });
 
-  it('should successfully import a ProcessModel, if it does not yet exist and overwriteExisting is set to false', async () => {
-
-    // This is to ensure that any existing process models will not falsify the results.
-    const uniqueImportName = uuid.v4();
+  it('should successfully import a ProcessModel', async () => {
 
     const importPayload = {
-      name: uniqueImportName,
-      xml: processModelAsXml,
-      overwriteExisting: false,
-    };
-
-    await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
-
-    await assertThatImportWasSuccessful();
-  });
-
-  it('should successfully import a ProcessModel, if it already exists and overwriteExisting is set to true', async () => {
-
-    // This is to ensure that any existing process models will not falsify the results.
-    const uniqueImportName = uuid.v4();
-
-    const importPayload = {
-      name: uniqueImportName,
+      name: processModelId,
       xml: processModelAsXml,
       overwriteExisting: true,
     };
 
-    // The value of overwriteExisting doesn't matter for the first import run.
     await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
-    await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
-
     await assertThatImportWasSuccessful();
   });
 
@@ -74,24 +58,19 @@ describe('Deployment API -> importBpmnFromXml', () => {
     };
 
     await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
-
     await assertThatImportWasSuccessful();
   });
 
   it('should fail to import a ProcessModel, if a process model by the same name exists, and overwriteExisting is set to false', async () => {
 
     try {
-
-      // This is to ensure that any existing process models will not falsify the results.
-      const uniqueImportName = uuid.v4();
-
       const importPayload = {
-        name: uniqueImportName,
+        name: processModelId,
         xml: processModelAsXml,
         overwriteExisting: false,
       };
 
-      // The value of overwriteExisting doesn't matter for the first import run.
+      // Run this twice to ensure that this test case is always executable.
       await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
       await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
 
@@ -140,6 +119,49 @@ describe('Deployment API -> importBpmnFromXml', () => {
       const expectedErrorMessage = /access denied/i;
       should(error.code).be.eql(expectedErrorCode);
       should(error.message).be.match(expectedErrorMessage);
+    }
+  });
+
+  // Note: Current restrictions state that a ProcessModel must have the same name as the Definition file.
+  // Otherwise the ProcessModel would not be retrievable.
+  it('should fail to import a ProcessModel, when the ProcessModel name does not match the ProcessDefinition name', async () => {
+
+    const importPayload = {
+      name: processModelIdNameMismatch,
+      xml: processModelPathNameMismatchAsXml,
+      overwriteExisting: false,
+    };
+
+    try {
+      await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
+      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+    } catch (error) {
+      const expectedErrorMessage = /ProcessModel contained within the diagram.*?must also use the name/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
+    }
+  });
+
+  // Note: This may be supported in future versions, but right now such a BPMN file would break everything.
+  // So we need to make sure that those types of ProcessModels do not get deployed.
+  // Otherwise, BPMN Studio will be unable to use the Runtime at all.
+  it('should fail to import a ProcessModel, when the file contains more than one Process', async () => {
+
+    const importPayload = {
+      name: processModelIdTooManyProcesses,
+      xml: processModelPathTooManyProcessesAsXml,
+      overwriteExisting: false,
+    };
+
+    try {
+      await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
+      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+    } catch (error) {
+      const expectedErrorMessage = /contains more than one ProcessModel/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
     }
   });
 

--- a/test/4_deployment_api/import_from_xml_local.js
+++ b/test/4_deployment_api/import_from_xml_local.js
@@ -134,7 +134,7 @@ describe('Deployment API -> importBpmnFromXml', () => {
 
     try {
       await testFixtureProvider.deploymentApiService.importBpmnFromXml(defaultIdentity, importPayload);
-      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+      should.fail(undefined, 'error', 'This request should have failed, because ProcessModel name differs from the ProcessDefinitions name!');
     } catch (error) {
       const expectedErrorMessage = /ProcessModel contained within the diagram.*?must also use the name/i;
       const expectedErrorCode = 422;

--- a/test/4_deployment_api/import_from_xml_remotely.js
+++ b/test/4_deployment_api/import_from_xml_remotely.js
@@ -142,7 +142,7 @@ describe(`Deployment API -> POST ${importRoute}`, () => {
 
     try {
       await httpClient.post(importRoute, importPayload, authHeadersDefault);
-      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+      should.fail(undefined, 'error', 'This request should have failed, because ProcessModel name differs from the ProcessDefinitions name!');
     } catch (error) {
       const expectedErrorMessage = /ProcessModel contained within the diagram.*?must also use the name/i;
       const expectedErrorCode = 422;

--- a/test/4_deployment_api/import_from_xml_remotely.js
+++ b/test/4_deployment_api/import_from_xml_remotely.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const should = require('should');
-const uuid = require('uuid');
 
 const TestFixtureProvider = require('../../dist/commonjs').TestFixtureProvider;
 
@@ -19,8 +18,13 @@ describe(`Deployment API -> POST ${importRoute}`, () => {
 
   const processModelId = 'generic_sample';
   const processModelIdNoLanes = 'process_model_without_lanes';
+  const processModelIdNameMismatch = 'process_model_name_mismatch';
+  const processModelIdTooManyProcesses = 'process_model_too_many_processes';
+
   let processModelAsXml;
   let processModelNoLanesAsXml;
+  let processModelPathNameMismatchAsXml;
+  let processModelPathTooManyProcessesAsXml;
 
   before(async () => {
     testFixtureProvider = new TestFixtureProvider();
@@ -31,6 +35,8 @@ describe(`Deployment API -> POST ${importRoute}`, () => {
 
     processModelAsXml = testFixtureProvider.readProcessModelFile(processModelId);
     processModelNoLanesAsXml = testFixtureProvider.readProcessModelFile(processModelIdNoLanes);
+    processModelPathNameMismatchAsXml = testFixtureProvider.readProcessModelFile(processModelIdNameMismatch);
+    processModelPathTooManyProcessesAsXml = testFixtureProvider.readProcessModelFile(processModelIdTooManyProcesses);
 
     httpClient = await testFixtureProvider.resolveAsync('HttpService');
   });
@@ -39,37 +45,15 @@ describe(`Deployment API -> POST ${importRoute}`, () => {
     await testFixtureProvider.tearDown();
   });
 
-  it('should successfully import a ProcessModel, if it does not yet exist and overwriteExisting is set to false', async () => {
-
-    // This is to ensure that any existing process models will not falsify the results.
-    const uniqueImportName = uuid.v4();
+  it('should successfully import a ProcessModel', async () => {
 
     const importPayload = {
-      name: uniqueImportName,
-      xml: processModelAsXml,
-      overwriteExisting: false,
-    };
-
-    await httpClient.post(importRoute, importPayload, authHeadersDefault);
-
-    await assertThatImportWasSuccessful();
-  });
-
-  it('should successfully import a ProcessModel, if it already exists and overwriteExisting is set to true', async () => {
-
-    // This is to ensure that any existing process models will not falsify the results.
-    const uniqueImportName = uuid.v4();
-
-    const importPayload = {
-      name: uniqueImportName,
+      name: processModelId,
       xml: processModelAsXml,
       overwriteExisting: true,
     };
 
-    // The value of overwriteExisting doesn't matter for the first import run.
     await httpClient.post(importRoute, importPayload, authHeadersDefault);
-    await httpClient.post(importRoute, importPayload, authHeadersDefault);
-
     await assertThatImportWasSuccessful();
   });
 
@@ -82,24 +66,19 @@ describe(`Deployment API -> POST ${importRoute}`, () => {
     };
 
     await httpClient.post(importRoute, importPayload, authHeadersDefault);
-
     await assertThatImportWasSuccessful();
   });
 
   it('should fail to import a ProcessModel, if a process model by the same name exists, and overwriteExisting is set to false', async () => {
 
     try {
-
-      // This is to ensure that any existing process models will not falsify the results.
-      const uniqueImportName = uuid.v4();
-
       const importPayload = {
-        name: uniqueImportName,
+        name: processModelId,
         xml: processModelAsXml,
         overwriteExisting: false,
       };
 
-      // The value of overwriteExisting doesn't matter for the first import run.
+      // Run this twice to ensure that this test case is always executable.
       await httpClient.post(importRoute, importPayload, authHeadersDefault);
       await httpClient.post(importRoute, importPayload, authHeadersDefault);
 
@@ -148,6 +127,49 @@ describe(`Deployment API -> POST ${importRoute}`, () => {
       const expectedErrorMessage = /access denied/i;
       should(error.code).be.eql(expectedErrorCode);
       should(error.message).be.match(expectedErrorMessage);
+    }
+  });
+
+  // Note: Current restrictions state that a ProcessModel must have the same name as the Definition file.
+  // Otherwise the ProcessModel would not be retrievable.
+  it('should fail to import a ProcessModel, when the ProcessModel name does not match the ProcessDefinition name', async () => {
+
+    const importPayload = {
+      name: processModelIdNameMismatch,
+      xml: processModelPathNameMismatchAsXml,
+      overwriteExisting: false,
+    };
+
+    try {
+      await httpClient.post(importRoute, importPayload, authHeadersDefault);
+      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+    } catch (error) {
+      const expectedErrorMessage = /ProcessModel contained within the diagram.*?must also use the name/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
+    }
+  });
+
+  // Note: This may be supported in future versions, but right now such a BPMN file would break everything.
+  // So we need to make sure that those types of ProcessModels do not get deployed.
+  // Otherwise, BPMN Studio will be unable to use the Runtime at all.
+  it('should fail to import a ProcessModel, when the file contains more than one Process', async () => {
+
+    const importPayload = {
+      name: processModelIdTooManyProcesses,
+      xml: processModelPathTooManyProcessesAsXml,
+      overwriteExisting: false,
+    };
+
+    try {
+      await httpClient.post(importRoute, importPayload, authHeadersDefault);
+      should.fail(undefined, 'error', 'This request should have failed, because the ProcessDefinition has more than one model!');
+    } catch (error) {
+      const expectedErrorMessage = /contains more than one ProcessModel/i;
+      const expectedErrorCode = 422;
+      should(error.message).be.match(expectedErrorMessage);
+      should(error.code).be.eql(expectedErrorCode);
     }
   });
 


### PR DESCRIPTION
**Requires:**
https://github.com/process-engine/process_engine_core/pull/234

**Changes:**

1. Add more validations for ProcessModel deployment
    - ProcessDefinitions must only contain one ProcessModel (Multiple ProcessModels are not supported right now)
    - A ProcessModels ID must match the provided name under which the definition is to be stored (See linked issue).
2. Add some error logging to the `ProcessModelService`
3. Refactor the Integrationtests for the Deployment API to accommodate these new restrictions 

**Issues:**

Closes #219 

PR: #220

## How can others test the changes?

Try deploying a ProcessDefinition that breaks one of these new restrictions mentioned above. It should not be possible any longer.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).