### PR TITLE
🐛 Use __dirname as default config path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ pipeline {
     stage('publish') {
       steps {
         script {
-          def new_commit = GIT_PREVIOUS_COMMIT != GIT_COMMIT;
+          def new_commit = env.GIT_PREVIOUS_COMMIT != GIT_COMMIT;
 
           if (branch_is_master) {
             if (new_commit) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "5.5.0",
+  "version": "5.4.1",
   "description": "Standalone application that provides access to the .TS implementation of the ProcessEngine.",
   "bin": {
     "process-engine": "./bin/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,7 +73,7 @@ function setConfigPath(): void {
   }
 
   const internalConfigFolderName: string = 'config';
-  const internalConfigPath: string = path.join(process.cwd(), internalConfigFolderName);
+  const internalConfigPath: string = path.join(__dirname, '..', '..', internalConfigFolderName);
 
   ensureConfigPathExists(internalConfigPath);
 


### PR DESCRIPTION
**Changes:**

1. use `__dirname` as the base path for the default config, to make it usable with the globally installed runtime
2. Add missing `env.` prefix to environment variable reference in Jenkinsfile

PR: #234

## How can others test the changes?

The configuration should now be loaded correctly with globally installed Runtimes.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).