### PR TITLE
🐛Escape special characters in xml during post migration

### DIFF
--- a/scripts/post-migrations/7.1.1-fix_sqlite_database_contents.js
+++ b/scripts/post-migrations/7.1.1-fix_sqlite_database_contents.js
@@ -92,10 +92,13 @@ async function moveProcessModelsFromFlowNodeInstanceDbToProcessModelDb(flowNodeI
 
   for (const processModel of processModelsToMove) {
 
+    // eslint-disable-next-line
+    const escapedXml = escape(processModel.xml);
+
     const updateQuery = `INSERT INTO ProcessDefinitions
                           (name, xml, hash, createdAt, updatedAt)
                           VALUES ('${processModel.name}',
-                                 '${processModel.xml}',
+                                 '${escapedXml}',
                                  '${processModel.hash}',
                                  '${processModel.createdAt}',
                                  '${processModel.updatedAt}');`;

--- a/scripts/post-migrations/7.1.1-fix_sqlite_database_contents.js
+++ b/scripts/post-migrations/7.1.1-fix_sqlite_database_contents.js
@@ -92,8 +92,7 @@ async function moveProcessModelsFromFlowNodeInstanceDbToProcessModelDb(flowNodeI
 
   for (const processModel of processModelsToMove) {
 
-    // eslint-disable-next-line
-    const escapedXml = escape(processModel.xml);
+    const escapedXml = processModel.xml.replace(/'/gi, '"');
 
     const updateQuery = `INSERT INTO ProcessDefinitions
                           (name, xml, hash, createdAt, updatedAt)


### PR DESCRIPTION
**Changes:**

Escape all special characters during the Post-migration script for Hotfix Version 7.1.1.

When dealing with ProcessModels that had `'` characters in them (like, say, when you have script task that performs something like `console.log('Hello');`, the SQLite query that moved the xml would fail with a parsing error.
This is because of the quotes contained in the `console.log` statement.

Escaping these characters fixes this issue.

PR: #299

## How can others test the changes?

Run the post-migration script on a a couple of databases that this script is supposed to fix.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).