### PR TITLE
:construction_worker: Fix Builds 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,35 +309,32 @@ pipeline {
         }
       }
     }
-    // TODO: The windows slave is currently extremly unstable, which causes our builds to crash frequently.
-    // Until this is fixed, this step should remain inactive.
-    //
-    // stage('Build Windows Installer') {
-    //   when {
-    //     expression {
-    //       currentBuild.result == 'SUCCESS' &&
-    //       (branch_is_master || branch_is_develop)
-    //     }
-    //   }
-    //   agent {
-    //     label 'windows'
-    //   }
-    //   steps {
+    stage('Build Windows Installer') {
+      when {
+        expression {
+          currentBuild.result == 'SUCCESS' &&
+          (branch_is_master || branch_is_develop)
+        }
+      }
+      agent {
+        label 'windows'
+      }
+      steps {
 
-    //     nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
-    //       bat('node --version')
-    //       bat('npm install')
-    //       bat('npm run build')
-    //       bat('npm rebuild')
+        nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
+          bat('node --version')
+          bat('npm install')
+          bat('npm run build')
+          bat('npm rebuild')
 
-    //       bat('npm run create-executable-windows')
-    //     }
+          bat('npm run create-executable-windows')
+        }
 
-    //     bat("$INNO_SETUP_ISCC /DProcessEngineRuntimeVersion=$full_release_version_string installer\\inno-installer.iss")
+        bat("$INNO_SETUP_ISCC /DProcessEngineRuntimeVersion=$full_release_version_string installer\\inno-installer.iss")
 
-    //     stash(includes: "installer\\Output\\Install ProcessEngine Runtime v${full_release_version_string}.exe", name: 'windows_installer_exe')
-    //   }
-    // }
+        stash(includes: "installer\\Output\\Install ProcessEngine Runtime v${full_release_version_string}.exe", name: 'windows_installer_exe')
+      }
+    }
     stage('publish') {
       when {
         expression {
@@ -399,7 +396,7 @@ pipeline {
       }
       steps {
 
-        // unstash('windows_installer_exe')
+        unstash('windows_installer_exe')
 
         withCredentials([
           usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'RELEASE_GH_TOKEN', usernameVariable: 'RELEASE_GH_USER')
@@ -413,7 +410,7 @@ pipeline {
             create_github_release_command += "${branch} ";
             create_github_release_command += "${release_will_be_draft} ";
             create_github_release_command += "${!branch_is_master} ";
-            // create_github_release_command += "installer/Output/Install\\ ProcessEngine\\ Runtime\\ v${full_release_version_string}.exe";
+            create_github_release_command += "installer/Output/Install\\ ProcessEngine\\ Runtime\\ v${full_release_version_string}.exe";
 
             sh(create_github_release_command);
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -402,7 +402,7 @@ pipeline {
         // unstash('windows_installer_exe')
 
         withCredentials([
-          string(credentialsId: 'process-engine-ci_github-token', variable: 'RELEASE_GH_TOKEN')
+          usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'RELEASE_GH_TOKEN', usernameVariable: 'RELEASE_GH_USER')
         ]) {
           script {
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
         nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
           sh('node --version')
           sh('npm install')
-          sh('npm run just-build')
+          sh('npm run build')
           sh('npm rebuild')
         }
 
@@ -324,7 +324,7 @@ pipeline {
         nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
           bat('node --version')
           bat('npm install')
-          bat('npm run just-build')
+          bat('npm run build')
           bat('npm rebuild')
 
           bat('npm run create-executable-windows')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
         nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
           sh('node --version')
           sh('npm install')
-          sh('npm run build')
+          sh('npm run just-build')
           sh('npm rebuild')
         }
 
@@ -324,7 +324,7 @@ pipeline {
         nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
           bat('node --version')
           bat('npm install')
-          bat('npm run build')
+          bat('npm run just-build')
           bat('npm rebuild')
 
           bat('npm run create-executable-windows')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "reinstall": "./reinstall.sh",
     "start": "node ./bin/index.js",
     "clean": "rm -rf dist",
-    "build": "npm run clean && npm run build-commonjs && npm run build-amd",
+    "build": "npm run clean && npm run just-build",
     "build-commonjs": "tsc",
     "build-amd": "tsc --module amd --outDir ./dist/amd",
     "lint": "eslint  src/**/**/*.ts src/**/*.ts src/*.ts",
@@ -23,7 +23,8 @@
     "test": "npm run test-sqlite",
     "test-all": "npm run test-sqlite && npm run test-postgres",
     "test-debug": "cross-env NODE_ENV=test-sqlite CONFIG_PATH=config mocha --inspect-brk test/**/*.js test/**/**/*.js  --exit",
-    "create-executable-windows": "pkg --targets windows ."
+    "create-executable-windows": "pkg --targets windows .",
+    "just-build": "npm run build-commonjs && npm run build-amd"
   },
   "main": "./dist/commonjs/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "reinstall": "./reinstall.sh",
     "start": "node ./bin/index.js",
     "clean": "rm -rf dist",
-    "build": "npm run clean && npm run just-build",
+    "build": "npm run build-commonjs && npm run build-amd",
+    "clean-build": "npm run clean && npm run build",
     "build-commonjs": "tsc",
     "build-amd": "tsc --module amd --outDir ./dist/amd",
     "lint": "eslint  src/**/**/*.ts src/**/*.ts src/*.ts",
@@ -23,8 +24,7 @@
     "test": "npm run test-sqlite",
     "test-all": "npm run test-sqlite && npm run test-postgres",
     "test-debug": "cross-env NODE_ENV=test-sqlite CONFIG_PATH=config mocha --inspect-brk test/**/*.js test/**/**/*.js  --exit",
-    "create-executable-windows": "pkg --targets windows .",
-    "just-build": "npm run build-commonjs && npm run build-amd"
+    "create-executable-windows": "pkg --targets windows ."
   },
   "main": "./dist/commonjs/index.js",
   "license": "MIT",


### PR DESCRIPTION
## Changes

1. 👷 Fix Wrong Usage of Credential Store
2. ⏪ Revert "🔥 👷 Disable building of windows installer"
3. ✨ Add Script For Only Building the Source 

## Issues

Closes 5minds/process_engine_infrastructure#33

PR: #333

## How to test the changes

See https://ci.process-engine.io/blue/organizations/jenkins/process-engine_node-lts%2Fprocess_engine_runtime/detail/feature%2Ffix_builds/6/pipeline/287