### PR TITLE
♻️ Store each ExternalTask's actual payload instead of the token expression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -680,9 +680,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.9.0-28f1b526-b2",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.9.0-28f1b526-b2.tgz",
-      "integrity": "sha512-rqTZT/M1RmoeA+pSiOVcuW+h+lXnZ0glH5XLgJF9j6DeVi0ooqxb1Go299F7V9r+JvsdwiBKpMoXAu2Y3GeKiA==",
+      "version": "12.9.0-a667cc48-b21",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.9.0-a667cc48-b21.tgz",
+      "integrity": "sha512-3yXZfK+jgy+9rY2Uac/K/7YBbTF3PI2JGLK28Q4xLyWDWC5fp4Fzy3oycZUW5lpjv5Yaswcq6miE8Fd4fykQFw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -680,9 +680,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.9.0-f46cf149-b20",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.9.0-f46cf149-b20.tgz",
-      "integrity": "sha512-TyY77WZf3+bB2Y50RyoHrYCrf05Rw2uaLtcWHYayCmX7his/9+n4zTN+zMD0e+W/Mol4+bZc0eD35b80ZcQGtg==",
+      "version": "12.9.0-28f1b526-b2",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.9.0-28f1b526-b2.tgz",
+      "integrity": "sha512-rqTZT/M1RmoeA+pSiOVcuW+h+lXnZ0glH5XLgJF9j6DeVi0ooqxb1Go299F7V9r+JvsdwiBKpMoXAu2Y3GeKiA==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^4.0.0",
@@ -2935,9 +2935,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
     "for-in": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@process-engine/management_api_http": "4.6.0-51ebb63d-b13",
     "@process-engine/metrics_api_core": "1.1.0",
     "@process-engine/metrics.repository.file_system": "1.2.0",
-    "@process-engine/process_engine_core": "12.9.0-f46cf149-b20",
+    "@process-engine/process_engine_core": "feature~fix_external_task_token_logging",
     "@process-engine/process_model.repository.sequelize": "6.0.1",
     "@process-engine/process_model.service": "1.2.0",
     "@process-engine/process_model.use_case": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@process-engine/management_api_http": "4.6.0-51ebb63d-b13",
     "@process-engine/metrics_api_core": "1.1.0",
     "@process-engine/metrics.repository.file_system": "1.2.0",
-    "@process-engine/process_engine_core": "feature~fix_external_task_token_logging",
+    "@process-engine/process_engine_core": "12.9.0-a667cc48-b21",
     "@process-engine/process_model.repository.sequelize": "6.0.1",
     "@process-engine/process_model.service": "1.2.0",
     "@process-engine/process_model.use_case": "1.3.0",


### PR DESCRIPTION
## Changes

1. Metrics for an ExternalTask will now get the task's actual payload, instead of the configured token expression.
2. The `on Suspend` token for each ExternalTask will also get the actual payload instead of the configured expression.

## Issues
 
Closes #352

PR: #356

## How to test the changes

- Run a ProcessModel that uses ExternalTasks
- After the ExternalTask was run, examine the generated metrics for the ProcessModel
- See that ExternalTask's actual payload is put with the metrics, instead of the configured token expression
