### PR TITLE
⚡️Add claim check caching

### DIFF
--- a/config/mysql/iam/iam_service.json
+++ b/config/mysql/iam/iam_service.json
@@ -1,5 +1,10 @@
 {
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
-  "disableClaimCheck": false
+  "disableClaimCheck": false,
+  "cache": {
+    "enabled": true,
+    "cacheLifetimeInSeconds": 300,
+    "cleanupIntervalInSeconds": 5
+  }
 }

--- a/config/postgres/iam/iam_service.json
+++ b/config/postgres/iam/iam_service.json
@@ -1,5 +1,10 @@
 {
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
-  "disableClaimCheck": false
+  "disableClaimCheck": false,
+  "cache": {
+    "enabled": true,
+    "cacheLifetimeInSeconds": 300,
+    "cleanupIntervalInSeconds": 5
+  }
 }

--- a/config/sqlite/iam/iam_service.json
+++ b/config/sqlite/iam/iam_service.json
@@ -1,5 +1,10 @@
 {
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
-  "disableClaimCheck": false
+  "disableClaimCheck": false,
+  "cache": {
+    "enabled": true,
+    "cacheLifetimeInSeconds": 300,
+    "cleanupIntervalInSeconds": 5
+  }
 }

--- a/config/test-mysql/iam/iam_service.json
+++ b/config/test-mysql/iam/iam_service.json
@@ -1,4 +1,9 @@
 {
   "basePath": "http://localhost:5000/",
-  "claimPath": "http://localhost:5000/claims/ensure"
+  "claimPath": "http://localhost:5000/claims/ensure",
+  "cache": {
+    "enabled": false,
+    "cacheLifetimeInSeconds": 30,
+    "cleanupIntervalInSeconds": 10
+  }
 }

--- a/config/test-postgres/iam/iam_service.json
+++ b/config/test-postgres/iam/iam_service.json
@@ -1,4 +1,9 @@
 {
   "basePath": "http://localhost:5000/",
-  "claimPath": "http://localhost:5000/claims/ensure"
+  "claimPath": "http://localhost:5000/claims/ensure",
+  "cache": {
+    "enabled": false,
+    "cacheLifetimeInSeconds": 30,
+    "cleanupIntervalInSeconds": 10
+  }
 }

--- a/config/test-sqlite/iam/iam_service.json
+++ b/config/test-sqlite/iam/iam_service.json
@@ -1,4 +1,9 @@
 {
   "basePath": "http://localhost:5000/",
-  "claimPath": "http://localhost:5000/claims/ensure"
+  "claimPath": "http://localhost:5000/claims/ensure",
+  "cache": {
+    "enabled": false,
+    "cacheLifetimeInSeconds": 30,
+    "cleanupIntervalInSeconds": 10
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,9 +482,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.6.0-8b7e4603-b22",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-8b7e4603-b22.tgz",
-      "integrity": "sha512-Z/6uOUYyjwr70aW7Po3lNfIj9IuuFp/AYZtGZ2OBqLYmBB7ZLosMVigmTaa4gArFIzYyul9l1y0NDczj/zZrwA==",
+      "version": "1.6.0-ce2f21d2-b27",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-ce2f21d2-b27.tgz",
+      "integrity": "sha512-Ddi3CR5dUTUbLCVJcofNTLeE4wXT2d57Tf5idNXEUTDaPUwsr4mS4P9VOe0Kn+l27reObhghoY7wdkmszcdNYg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,9 +482,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.6.0-96178cb6-b29",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-96178cb6-b29.tgz",
-      "integrity": "sha512-7wnnE3DiAchS4gnTwJk1CSicJRVXF/6Z0weik0gNV4xQ6/mywmC6EE4jCG7YI48sG0CngXQyBlrtXyY+SKEuHQ==",
+      "version": "1.6.0-1aa5cc7a-b30",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-1aa5cc7a-b30.tgz",
+      "integrity": "sha512-aCL8bTyFrSEukaSVH0/HkWmKk6l6uPy7cxHcQLe/9XIW4hDsveqg1WBXELYdgGV6lXO2+LR/tPKiXZ1JoA6HPA==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -482,9 +482,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.6.0-ce2f21d2-b27",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-ce2f21d2-b27.tgz",
-      "integrity": "sha512-Ddi3CR5dUTUbLCVJcofNTLeE4wXT2d57Tf5idNXEUTDaPUwsr4mS4P9VOe0Kn+l27reObhghoY7wdkmszcdNYg==",
+      "version": "1.6.0-96178cb6-b29",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-96178cb6-b29.tgz",
+      "integrity": "sha512-7wnnE3DiAchS4gnTwJk1CSicJRVXF/6Z0weik0gNV4xQ6/mywmC6EE4jCG7YI48sG0CngXQyBlrtXyY+SKEuHQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,14 +482,15 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.5.0.tgz",
-      "integrity": "sha512-ph1ThvMotnUMt4TjCXKAZ3msWatpu2/y38VkAVeN9XR7yFaEx5hfPovV79CrYh5l1GDwjarLqvf41d65YdVtpQ==",
+      "version": "1.6.0-8b7e4603-b22",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-8b7e4603-b22.tgz",
+      "integrity": "sha512-Z/6uOUYyjwr70aW7Po3lNfIj9IuuFp/AYZtGZ2OBqLYmBB7ZLosMVigmTaa4gArFIzYyul9l1y0NDczj/zZrwA==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",
-        "@essential-projects/iam_contracts": "^3.4.0",
-        "loggerhythm": "^3.0.3"
+        "@essential-projects/iam_contracts": "^3.6.0",
+        "loggerhythm": "^3.0.3",
+        "moment": "^2.24.0"
       }
     },
     "@process-engine/kpi_api_contracts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -482,9 +482,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.6.0-1aa5cc7a-b30",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-1aa5cc7a-b30.tgz",
-      "integrity": "sha512-aCL8bTyFrSEukaSVH0/HkWmKk6l6uPy7cxHcQLe/9XIW4hDsveqg1WBXELYdgGV6lXO2+LR/tPKiXZ1JoA6HPA==",
+      "version": "1.6.0-afee79fe-b7",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.0-afee79fe-b7.tgz",
+      "integrity": "sha512-kLv5/LTbUPMv4OpfvaRXimGP0e/xynrOht11PMZJIV1Hh7Q8Y8EBkAxgDWltKo4RnhjyxU758EzWqm596iR8fQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@process-engine/external_task.repository.sequelize": "3.0.1",
     "@process-engine/flow_node_instance.repository.sequelize": "10.1.0",
     "@process-engine/flow_node_instance.service": "1.1.0",
-    "@process-engine/iam": "1.5.0",
+    "@process-engine/iam": "feature~add_claim_check_caching",
     "@process-engine/kpi_api_http": "1.4.0",
     "@process-engine/kpi_api_core": "2.1.0",
     "@process-engine/logging_api_http": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@process-engine/external_task.repository.sequelize": "3.0.1",
     "@process-engine/flow_node_instance.repository.sequelize": "10.1.0",
     "@process-engine/flow_node_instance.service": "1.1.0",
-    "@process-engine/iam": "feature~add_claim_check_caching",
+    "@process-engine/iam": "1.6.0-afee79fe-b7",
     "@process-engine/kpi_api_http": "1.4.0",
     "@process-engine/kpi_api_core": "2.1.0",
     "@process-engine/logging_api_http": "1.1.0",


### PR DESCRIPTION
## Changes

1. Implement claim check caching into iam package
    - Full Changelog `@process-engine/iam`: https://github.com/process-engine/iam/pull/11
2. Add production- and test- configs for claim check caching
    - The default settings for the cache give a 5 minute lifetime for each cache entry and will tell the cache to clean itself up every 5 seconds
    - **NOTE:** Since the tests use a mocked IAM service, the configs are never actually used. They were only added so that they mirror the production configs

## Issues

Closes #358

PR: #361

## How to test the changes

The tests should all work as before.

For use in a productive environment, this is best tested with a setup that uses large amounts of BPMNs and/or BPMNs with multiple lanes.
You should notice a considerable increase in performance, when pulling these BPMNs frequently.
