### PR TITLE
🐛 Fix timer event parsing

### DIFF
--- a/bpmn/cyclic_timers_test_no_enabled_property.bpmn
+++ b/bpmn/cyclic_timers_test_no_enabled_property.bpmn
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_019scie" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.15.1">
+  <bpmn:collaboration id="Collaboration_1dwnbx6">
+    <bpmn:participant id="Participant_1ndejx1" name="cyclic_timers_test_no_enabled_property" processRef="cyclic_timers_test_no_enabled_property" />
+  </bpmn:collaboration>
+  <bpmn:process id="cyclic_timers_test_no_enabled_property" name="cyclic_timers_test_no_enabled_property" isExecutable="true">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1jhpx27" name="Default_Test_Lane">
+        <bpmn:flowNodeRef>EndEvent_TimerTest</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>ScriptTaskTimerEvent_1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>TimerStartEvent_1</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:sequenceFlow id="SequenceFlow_0x9ie3k" sourceRef="TimerStartEvent_1" targetRef="ScriptTaskTimerEvent_1" />
+    <bpmn:sequenceFlow id="SequenceFlow_07eg0vm" sourceRef="ScriptTaskTimerEvent_1" targetRef="EndEvent_TimerTest" />
+    <bpmn:endEvent id="EndEvent_TimerTest" name="End">
+      <bpmn:incoming>SequenceFlow_07eg0vm</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:scriptTask id="ScriptTaskTimerEvent_1" name="Return sample result">
+      <bpmn:incoming>SequenceFlow_0x9ie3k</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_07eg0vm</bpmn:outgoing>
+      <bpmn:script>console.log('Process with cronjob started!');
+
+return 'Success';</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:startEvent id="TimerStartEvent_1" name="Timer with Crontab">
+      <bpmn:extensionElements>
+        <camunda:properties>
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>SequenceFlow_0x9ie3k</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">*/2 * * * * *</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:message id="Message_18zwda3" name="MessageAutoStart_Test" />
+  <bpmn:signal id="Signal_1gmrdgn" name="SignalAutoStart_Test" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1dwnbx6">
+      <bpmndi:BPMNShape id="Participant_1ndejx1_di" bpmnElement="Participant_1ndejx1">
+        <dc:Bounds x="111" y="23" width="427" height="186" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0x9ie3k_di" bpmnElement="SequenceFlow_0x9ie3k">
+        <di:waypoint x="234" y="104" />
+        <di:waypoint x="311" y="104" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="233" y="189.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0bw7vw9_di" bpmnElement="EndEvent_TimerTest">
+        <dc:Bounds x="481" y="86" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="489" y="125" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1jhpx27_di" bpmnElement="Lane_1jhpx27">
+        <dc:Bounds x="141" y="23" width="397" height="186" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_07eg0vm_di" bpmnElement="SequenceFlow_07eg0vm">
+        <di:waypoint x="411" y="104" />
+        <di:waypoint x="481" y="104" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_18ruani_di" bpmnElement="ScriptTaskTimerEvent_1">
+        <dc:Bounds x="311" y="64" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_01qhzro_di" bpmnElement="TimerStartEvent_1">
+        <dc:Bounds x="198" y="86" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="191" y="125" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -702,9 +702,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.10.0.tgz",
-      "integrity": "sha512-KwleTok/4XfgEBen4dOhcNWw+/ztLr+olyNTJTVrByJ1ZHjzOYH+JNK/UuW1PYPDnnv7zu5AikVoT7NYCwLoHA==",
+      "version": "12.10.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.10.1.tgz",
+      "integrity": "sha512-Tx+qwIRlKtSSZnju4yqHgumyAuPy+DoqCs4wbQFdwHh9ClEu9Kvur0+h7+C70Ylumo/2KSlJ3HymFTd0s32WHw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
@@ -1031,12 +1031,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.11.0.tgz",
-      "integrity": "sha512-mXv9ccCou89C8/4avKHuPB2WkSZyY/XcTQUXd5LFZAcLw1I3mWYVjUu6eS9Ja0QkP/ClolbcW9tb3Ov/pMdcqw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.12.0.tgz",
+      "integrity": "sha512-J/ZTZF+pLNqjXBGNfq5fahsoJ4vJOkYbitWPavA05IrZ7BXUaf4XWlhUB/ic1lpOGTRpLWF+PLAePjiHp6dz8g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "1.11.0",
+        "@typescript-eslint/experimental-utils": "1.12.0",
         "eslint-utils": "^1.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
@@ -1044,31 +1044,31 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.11.0.tgz",
-      "integrity": "sha512-7LbfaqF6B8oa8cp/315zxKk8FFzosRzzhF8Kn/ZRsRsnpm7Qcu25cR/9RnAQo5utZ2KIWVgaALr+ZmcbG47ruw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.12.0.tgz",
+      "integrity": "sha512-s0soOTMJloytr9GbPteMLNiO2HvJ+qgQkRNplABXiVw6vq7uQRvidkby64Gqt/nA7pys74HksHwRULaB/QRVyw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "1.11.0",
+        "@typescript-eslint/typescript-estree": "1.12.0",
         "eslint-scope": "^4.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.11.0.tgz",
-      "integrity": "sha512-5xBExyXaxVyczrZvbRKEXvaTUFFq7gIM9BynXukXZE0zF3IQP/FxF4mPmmh3gJ9egafZFqByCpPTFm3dk4SY7Q==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.12.0.tgz",
+      "integrity": "sha512-0uzbaa9ZLCA5yMWJywnJJ7YVENKGWVUhJDV5UrMoldC5HoI54W5kkdPhTfmtFKpPFp93MIwmJj0/61ztvmz5Dw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "1.11.0",
-        "@typescript-eslint/typescript-estree": "1.11.0",
+        "@typescript-eslint/experimental-utils": "1.12.0",
+        "@typescript-eslint/typescript-estree": "1.12.0",
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.11.0.tgz",
-      "integrity": "sha512-fquUHF5tAx1sM2OeRCC7wVxFd1iMELWMGCzOSmJ3pLzArj9+kRixdlC4d5MncuzXpjEqc6045p3KwM0o/3FuUA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.12.0.tgz",
+      "integrity": "sha512-nwN6yy//XcVhFs0ZyU+teJHB8tbCm7AIA8mu6E2r5hu6MajwYBY3Uwop7+rPZWUN/IUOHpL8C+iUPMDVYUU3og==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -1124,9 +1124,9 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
     },
     "ajv": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
-      "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2460,10 +2460,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -3482,9 +3485,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
-      "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+      "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.2.0",
@@ -3493,7 +3496,7 @@
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
@@ -3979,9 +3982,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -6300,9 +6303,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "split": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@process-engine/management_api_http": "4.7.0",
     "@process-engine/metrics_api_core": "2.0.0",
     "@process-engine/metrics.repository.file_system": "2.0.0",
-    "@process-engine/process_engine_core": "12.10.0",
+    "@process-engine/process_engine_core": "12.10.1",
     "@process-engine/process_model.repository.sequelize": "6.0.1",
     "@process-engine/process_model.service": "1.2.0",
     "@process-engine/process_model.use_case": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "Standalone application that provides access to the .TS implementation of the ProcessEngine.",
   "bin": {
     "process-engine": "./bin/index.js"

--- a/test/1_process_engine/start_event_cyclic_timers_tests.js
+++ b/test/1_process_engine/start_event_cyclic_timers_tests.js
@@ -12,6 +12,7 @@ describe('StartEvents with Cronjobs - ', () => {
 
   const processModelId = 'cyclic_timers_test';
   const processModelId2 = 'cyclic_timers_test_2';
+  const processModelIdMissingCamundaProperty = 'cyclic_timers_test_no_enabled_property';
   const processModelIdDisabled = 'cyclic_timers_disabled';
 
   before(async () => {
@@ -27,6 +28,7 @@ describe('StartEvents with Cronjobs - ', () => {
   after(async () => {
     await disposeProcessModel(processModelId);
     await disposeProcessModel(processModelId2);
+    await disposeProcessModel(processModelIdMissingCamundaProperty);
 
     await testFixtureProvider.tearDown();
   });
@@ -84,6 +86,24 @@ describe('StartEvents with Cronjobs - ', () => {
       const parsedProcessModel2 = await getParsedProcessModel(processModelId2);
 
       await cronjobService.addOrUpdate(parsedProcessModel2);
+    });
+  });
+
+  it('should assume a TimerStartEvent to be enabled by default, if no CamundaProperty \'enabled\' exists.', async () => {
+
+    return new Promise(async (resolve, reject) => {
+      const correlationId = 'started_by_cronjob';
+
+      processInstanceHandler.waitForProcessInstanceToEnd(correlationId, processModelIdMissingCamundaProperty, async() => {
+        await cronjobService.stop();
+        resolve();
+      });
+
+      await cronjobService.start();
+
+      const parsedProcessModel = await getParsedProcessModel(processModelIdMissingCamundaProperty);
+
+      await cronjobService.addOrUpdate(parsedProcessModel);
     });
   });
 


### PR DESCRIPTION
## Changes

Fix an issue that prevented TimerDefinitions from being parsed, if the corresponding XML is missing an `enabled` CamundaProperty.

## Issues

PR: #375

## How to test the changes

- Upload a ProcessModel with any kind of TimerEvent that is missing a CamundaProperty `enabled`
- Make a `Get ProcessModels` call
- See that you'll get a list of your ProcessModels