### PR TITLE
🔥Disconnect ManagementApi from ConsumerApi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -591,9 +591,9 @@
       }
     },
     "@process-engine/management_api_core": {
-      "version": "6.0.0-d14c54dc-b8",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.0.0-d14c54dc-b8.tgz",
-      "integrity": "sha512-NHoHiVi0Q05DpUrtHtKk/f6un9KyBEOsn4m9JnIIeLoRHTP4eHd8+QeNpbD2QyKRTAp4Mtoe0AANrSExxK/TtA==",
+      "version": "6.0.0-54a1f693-b25",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.0.0-54a1f693-b25.tgz",
+      "integrity": "sha512-mZpPSXDrNl6N93FloQpgUjUaA5DuQVck9QnyxbCZdzUPgq6kI5HQ3nh7j71wb5xfOUw75EU6GLY10Z7IypuEjw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@process-engine/correlation.contracts": "^2.0.0",
@@ -6640,9 +6640,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.15.0.tgz",
-      "integrity": "sha512-or184xKZ6fLE1SrDcvsOs3Wkfb1JgizdKs5Fiag3cp/m9k7C7GWd4E7gs3K5LHAePaIP7K62C20ZZI3JQx8iBQ==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.0.tgz",
+      "integrity": "sha512-fyveWOtAXfumAxIqkcMHuPaaVyLBKjB8Y00ANZkqh+HITBAQscCbQIHwwBTJdvQq7RykLEbOPcUUnJ16X4NA0g==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -591,11 +591,11 @@
       }
     },
     "@process-engine/management_api_core": {
-      "version": "6.0.0-2bd28596-b24",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.0.0-2bd28596-b24.tgz",
-      "integrity": "sha512-5VcIXJmmhl034CFqBsd7RkANfZGZa1sRqA2nrrVjG2D1v/QJi7jBSIwj7JqIe+2kY6cbWNWKEAqWsEbwRiaGJg==",
+      "version": "6.0.0-d14c54dc-b8",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.0.0-d14c54dc-b8.tgz",
+      "integrity": "sha512-NHoHiVi0Q05DpUrtHtKk/f6un9KyBEOsn4m9JnIIeLoRHTP4eHd8+QeNpbD2QyKRTAp4Mtoe0AANrSExxK/TtA==",
       "requires": {
-        "@process-engine/consumer_api_contracts": "8.0.0-dad26234-b24",
+        "@essential-projects/errors_ts": "^1.5.0",
         "@process-engine/correlation.contracts": "^2.0.0",
         "@process-engine/cronjob_history.contracts": "^1.0.0",
         "@process-engine/flow_node_instance.contracts": "^2.0.0",
@@ -608,7 +608,8 @@
         "bluebird": "~3.5.2",
         "bluebird-global": "~1.0.1",
         "clone": "~2.1.2",
-        "moment": "~2.24.0"
+        "moment": "~2.24.0",
+        "node-uuid": "^1.4.8"
       }
     },
     "@process-engine/management_api_http": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@process-engine/logging_api_http": "1.1.0",
     "@process-engine/logging_api_core": "1.1.0",
     "@process-engine/logging.repository.file_system": "1.3.0",
-    "@process-engine/management_api_core": "6.0.0-2bd28596-b24",
+    "@process-engine/management_api_core": "feature~remove_consumer_api",
     "@process-engine/management_api_http": "5.0.0-450a1201-b19",
     "@process-engine/metrics_api_core": "2.0.0",
     "@process-engine/metrics.repository.file_system": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@process-engine/logging_api_http": "1.1.0",
     "@process-engine/logging_api_core": "1.1.0",
     "@process-engine/logging.repository.file_system": "1.3.0",
-    "@process-engine/management_api_core": "feature~remove_consumer_api",
+    "@process-engine/management_api_core": "6.0.0-54a1f693-b25",
     "@process-engine/management_api_http": "5.0.0-450a1201-b19",
     "@process-engine/metrics_api_core": "2.0.0",
     "@process-engine/metrics.repository.file_system": "2.0.0",


### PR DESCRIPTION
## Changes

1. Decouple the ManagementApiCore from the ConsumerApi
2. Add customized implementations for all services that previously used the Consumer API
    - These services are implemented in the same way their counterparts from the ConsumerAPI are

## Issues

PR #385

## How to test the changes

The end user shouldn't notice any differences.
