### PR TITLE
👷 Use default SQLite storage path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,20 +241,14 @@ pipeline {
             unstash('post_build');
 
             script {
+              def node_env = 'NODE_ENV=test-sqlite';
+              def api_mode = 'API_ACCESS_TYPE=internal ';
               def junit_report_path = 'JUNIT_REPORT_PATH=process_engine_runtime_integration_tests_sqlite.xml';
-              def config_path = 'CONFIG_PATH=/usr/src/app/config';
-              def api_access_mode = '--env API_ACCESS_TYPE=internal ';
+              def config_path = 'CONFIG_PATH=config';
 
-              def db_storage_folder_path = "$WORKSPACE/process_engine_databases";
-              def db_storage_path_correlation = "process_engine__correlation_repository__storage=$db_storage_folder_path/correlation.sqlite";
-              def db_storage_path_cronjob_history = "process_engine__cronjob_history_repository__storage=$db_storage_folder_path/cronjob_history.sqlite";
-              def db_storage_path_external_task = "process_engine__external_task_repository__storage=$db_storage_folder_path/external_task.sqlite";
-              def db_storage_path_process_model = "process_engine__process_model_repository__storage=$db_storage_folder_path/process_model.sqlite";
-              def db_storage_path_flow_node_instance = "process_engine__flow_node_instance_repository__storage=$db_storage_folder_path/flow_node_instance.sqlite";
+              def node_env_settings = "${node_env} ${api_mode} ${junit_report_path} ${config_path}"
 
-              def db_environment_settings = "jenkinsDbStoragePath=${db_storage_folder_path} ${db_storage_path_cronjob_history} ${db_storage_path_correlation} ${db_storage_path_external_task} ${db_storage_path_process_model} ${db_storage_path_flow_node_instance}";
-
-              def npm_test_command = "node ./node_modules/.bin/cross-env NODE_ENV=test-sqlite JUNIT_REPORT_PATH=process_engine_runtime_integration_tests_sqlite.xml CONFIG_PATH=config API_ACCESS_TYPE=internal ${db_environment_settings} ./node_modules/.bin/mocha -t 20000 test/**/*.js test/**/**/*.js";
+              def npm_test_command = "node ./node_modules/.bin/cross-env ${node_env_settings} ./node_modules/.bin/mocha -t 20000 test/**/*.js test/**/**/*.js";
 
               docker.image("node:${NODE_VERSION_NUMBER}").inside("--env PATH=$PATH:/$WORKSPACE/node_modules/.bin") {
                 sqlite_exit_code = sh(script: "${npm_test_command} --colors --reporter mocha-jenkins-reporter --exit > process_engine_runtime_integration_tests_sqlite.txt", returnStatus: true);

--- a/test/1_process_engine/parallel_gateway_test.js
+++ b/test/1_process_engine/parallel_gateway_test.js
@@ -1,8 +1,6 @@
 const should = require('should');
 const uuid = require('node-uuid');
 
-const StartCallbackType = require('@process-engine/management_api_contracts').DataModels.ProcessModels.StartCallbackType;
-
 const {ProcessInstanceHandler, TestFixtureProvider} = require('../../dist/commonjs/test_setup');
 
 describe('Parallel Gateway execution', () => {
@@ -125,21 +123,16 @@ describe('Parallel Gateway execution', () => {
     });
   });
 
-  it('should finish parallel gateway by finished flow nodes', async () => {
+  it('should finish a ParallelJoinGateway when each expected incoming FlowNode has been executed at least once', async () => {
 
+    const startEventIdToUse = 'StartEvent_1';
     const correlationId = uuid.v4();
-    const payload = {
-      correlationId: correlationId,
-    };
-    const returnOn = StartCallbackType.CallbackOnProcessInstanceFinished;
 
-    const result = await testFixtureProvider
-      .managementApiClient
-      .startProcessInstance(defaultIdentity, parallelGatewayFinishTestId, payload, returnOn);
+    const result = await testFixtureProvider.executeProcess(processModelParallelJoinGatewayBranchingTest, startEventIdToUse, correlationId, {});
 
-    should(result.tokenPayload).have.size(2, 'There should be two entries in the final token payload!');
-    should(result.tokenPayload).have.property('ExclusiveGateway1');
-    should(result.tokenPayload).have.property('ScriptTask1');
+    should(Object.keys(result.currentToken)).have.length(2, 'There should be two entries in the final token payload!');
+    should(result.currentToken).have.property('ExclusiveGateway1');
+    should(result.currentToken).have.property('ScriptTask1');
   });
 
   it('should finish two parallel running EmptyActivities', async () => {

--- a/test/1_process_engine/parallel_gateway_test.js
+++ b/test/1_process_engine/parallel_gateway_test.js
@@ -12,9 +12,9 @@ describe('Parallel Gateway execution', () => {
   const startEventId = 'StartEvent_1';
 
   const processModelId = 'parallel_gateway_test';
-  const parallelGatewayFinishTestId = 'parallel_gateway_finish_test';
   const processModelIdUnsupported = 'parallel_gateway_unsupported_test';
   const processModelParallelEmptyActivitiesId = 'empty_activity_test';
+  const processModelParallelJoinGatewayBranchingTest = 'parallel_gateway_finish_test';
   const processModelParallelManualTasksId = 'manual_task_parallel_test';
   const processModelParallelUserTasksId = 'user_task_parallel_test';
 
@@ -28,9 +28,9 @@ describe('Parallel Gateway execution', () => {
       processModelId,
       processModelIdUnsupported,
       processModelParallelEmptyActivitiesId,
+      processModelParallelJoinGatewayBranchingTest,
       processModelParallelManualTasksId,
       processModelParallelUserTasksId,
-      parallelGatewayFinishTestId,
     ];
 
     await testFixtureProvider.importProcessFiles(processDefFileList);

--- a/test/5_metrics_api/metrics_api_test.js
+++ b/test/5_metrics_api/metrics_api_test.js
@@ -5,6 +5,8 @@ const path = require('path');
 const should = require('should');
 const uuid = require('node-uuid');
 
+const StartCallbackType = require('@process-engine/management_api_contracts').DataModels.ProcessModels.StartCallbackType;
+
 const {ProcessInstanceHandler, TestFixtureProvider} = require('../../dist/commonjs/test_setup');
 
 describe('Metric API Tests - ', () => {
@@ -25,7 +27,7 @@ describe('Metric API Tests - ', () => {
 
     processInstanceHandler = new ProcessInstanceHandler(testFixtureProvider);
 
-    await executeSampleProcess();
+    await createFinishedProcessInstance();
   });
 
   after(async () => {
@@ -92,7 +94,7 @@ describe('Metric API Tests - ', () => {
     }
   });
 
-  async function executeSampleProcess() {
+  async function createFinishedProcessInstance() {
 
     const payload = {
       correlationId: correlationId,
@@ -101,13 +103,11 @@ describe('Metric API Tests - ', () => {
       },
     };
 
-    return new Promise(async (resolve) => {
-      const result = await testFixtureProvider
-        .managementApiClient
-        .startProcessInstance(testFixtureProvider.identities.defaultUser, processModelId, payload);
+    const returnOn = StartCallbackType.CallbackOnProcessInstanceFinished;
 
-      processInstanceHandler.waitForProcessWithInstanceIdToEnd(result.processInstanceId, resolve);
-    });
+    await testFixtureProvider
+      .managementApiClient
+      .startProcessInstance(testFixtureProvider.identities.defaultUser, processModelId, payload, returnOn);
   }
 
   function readMetricsFile() {

--- a/test/5_metrics_api/metrics_api_test.js
+++ b/test/5_metrics_api/metrics_api_test.js
@@ -108,6 +108,9 @@ describe('Metric API Tests - ', () => {
     await testFixtureProvider
       .managementApiClient
       .startProcessInstance(testFixtureProvider.identities.defaultUser, processModelId, payload, returnOn);
+
+    // Metrics are written outside of the main Promise-Chain, so give the backend some time to finish writing the metrics.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
   function readMetricsFile() {


### PR DESCRIPTION
## Changes

1. Use default SQLite storage path during CI builds.
2. Remove Management API references from ParallelGateway tests
3. Add buffer to MetricsAPI tests to avoid sync errors
4. Cleanup after the `Build Windows Installer` and `SQLite Test` steps

## Issues

PR: #402

## How to test the changes

Watch some CI builds.
https://ci.process-engine.io/blue/organizations/jenkins/process-engine_node-lts%2Fprocess_engine_runtime/detail/feature%2Fuse_default_storage_path_for_sqlite_databases/1/pipeline/72