### PR TITLE
🔧 Add "allowGodToken" config for iam service

### DIFF
--- a/config/mysql/iam/iam_service.json
+++ b/config/mysql/iam/iam_service.json
@@ -2,6 +2,7 @@
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
   "disableClaimCheck": false,
+  "allowGodToken": false,
   "cache": {
     "enabled": true,
     "cacheLifetimeInSeconds": 300,

--- a/config/postgres/iam/iam_service.json
+++ b/config/postgres/iam/iam_service.json
@@ -2,6 +2,7 @@
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
   "disableClaimCheck": false,
+  "allowGodToken": false,
   "cache": {
     "enabled": true,
     "cacheLifetimeInSeconds": 300,

--- a/config/sqlite/iam/iam_service.json
+++ b/config/sqlite/iam/iam_service.json
@@ -2,6 +2,7 @@
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
   "disableClaimCheck": false,
+  "allowGodToken": false,
   "cache": {
     "enabled": true,
     "cacheLifetimeInSeconds": 300,

--- a/config/sqlite/iam/iam_service.json
+++ b/config/sqlite/iam/iam_service.json
@@ -2,7 +2,7 @@
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
   "disableClaimCheck": false,
-  "allowGodToken": false,
+  "allowGodToken": true,
   "cache": {
     "enabled": true,
     "cacheLifetimeInSeconds": 300,

--- a/config/test-mysql/iam/iam_service.json
+++ b/config/test-mysql/iam/iam_service.json
@@ -1,6 +1,8 @@
 {
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
+  "disableClaimCheck": false,
+  "allowGodToken": true,
   "cache": {
     "enabled": false,
     "cacheLifetimeInSeconds": 30,

--- a/config/test-postgres/iam/iam_service.json
+++ b/config/test-postgres/iam/iam_service.json
@@ -1,6 +1,8 @@
 {
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
+  "disableClaimCheck": false,
+  "allowGodToken": true,
   "cache": {
     "enabled": false,
     "cacheLifetimeInSeconds": 30,

--- a/config/test-sqlite/iam/iam_service.json
+++ b/config/test-sqlite/iam/iam_service.json
@@ -1,6 +1,8 @@
 {
   "basePath": "http://localhost:5000/",
   "claimPath": "http://localhost:5000/claims/ensure",
+  "disableClaimCheck": false,
+  "allowGodToken": true,
   "cache": {
     "enabled": false,
     "cacheLifetimeInSeconds": 30,

--- a/package-lock.json
+++ b/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "@essential-projects/iam_contracts": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.6.0.tgz",
-      "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.6.1.tgz",
+      "integrity": "sha512-B9EWOjDvXCklajeP2XPy6BWT5oQXRagWExZCWYbe3X9kokEiG5XD4yvi9bPWPeoJYXnk3Zh969uM5sESF+71oA=="
     },
     "@essential-projects/sequelize_connection_manager": {
       "version": "3.0.1",
@@ -494,9 +494,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.6.1-3b7e87b1-b9",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.6.1-3b7e87b1-b9.tgz",
-      "integrity": "sha512-DFf8ohZmaf3M30hA1u74D9Cah5+myK4K5XJtWIINB8+XyrNmaoOFMFrN/pPBhXySJe0DLpWNwv2ZD7Inl6hE4Q==",
+      "version": "1.7.0-6d9abf5d-b10",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.0-6d9abf5d-b10.tgz",
+      "integrity": "sha512-FmXHoWJENasWUbG7Tqz1X17QicgXEQwDV60gNV3cluXr9q/z5rf0TlDYXN1kMOuUCIrA847BXt5fzt2+6qYTKA==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@process-engine/external_task.repository.sequelize": "3.1.0-46b8d50d-b17",
     "@process-engine/flow_node_instance.repository.sequelize": "10.2.0-2f1cbe0c-b14",
     "@process-engine/flow_node_instance.service": "1.2.0-761da644-b10",
-    "@process-engine/iam": "1.6.1-3b7e87b1-b9",
+    "@process-engine/iam": "1.7.0-6d9abf5d-b10",
     "@process-engine/logging_api_core": "1.1.0",
     "@process-engine/logging.repository.file_system": "1.3.0",
     "@process-engine/management_api_core": "6.1.0-714a67c2-b35",


### PR DESCRIPTION
## Changes

1. Adds the `allowGodToken` config option to the IamService's config, which can be used to allow or disallow the use of the "dummy token".
2. Allow dummy token per default for all test environments
3. Disallow dummy token per default for all production environments, except SQLite
    -  We can't do that yet, because this is the default Config for the BPMN Studio, which does not yet have a mechanism for updating its config at startup
    - This will be changed as soon as the Studio is able to make adjustments to the runtime's config

## Issues

Closes #414

PR: #416

## How to test the changes

- Make requests with the dummy token against the runtime, while using an environment that has `allowGodToken` set to false.
- This shouldn't work anymore.