### PR TITLE
🐛 Betafix: Cache by token instead of UserId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.7.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.0-beta.1.tgz",
-      "integrity": "sha512-wsZIpV0Fcqei4UuZ2J1RJ1SthLqcV8uF5QVjtvybPNd5Hv842qqqvYjNyla381G06Tock8lKi/7HIdA7LfCeSQ==",
+      "version": "1.7.0-betafix-906d07-k0w34f3s",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.0-betafix-906d07-k0w34f3s.tgz",
+      "integrity": "sha512-lYlppFqn+OFm4yhWhtrxfM/UmrvgoZfap9BzNQdHuue6rEtxCxWNj5yXt3EV5j9+EUcO74BM7fSr72bFbrOkgg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",
@@ -3195,9 +3195,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.1.tgz",
+      "integrity": "sha512-bqPIlDk06UWbVEIFoYj+LVo42WhK96J+b25l7hbFDpxrOXMphFM3fNIm+cluwg4Pk2jiLjWU5nHQY7igGE75NQ==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -4258,9 +4258,9 @@
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "minipass": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.6.5.tgz",
-      "integrity": "sha512-ewSKOPFH9blOLXx0YSE+mbrNMBFPS+11a2b03QZ+P4LVrUHW/GAlqeYC7DBknDyMWkHzrzTpDhUvy7MUxqyrPA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.1.tgz",
+      "integrity": "sha512-QCG523ParRcE2+9A6wYh9UI3uy2FFLw4DQaVYQrY5HPfszc5M6VDD+j0QCwHm19LI2imes4RB+NBD8cOJccyCg==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -494,9 +494,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.7.0-betafix-906d07-k0w34f3s",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.0-betafix-906d07-k0w34f3s.tgz",
-      "integrity": "sha512-lYlppFqn+OFm4yhWhtrxfM/UmrvgoZfap9BzNQdHuue6rEtxCxWNj5yXt3EV5j9+EUcO74BM7fSr72bFbrOkgg==",
+      "version": "1.7.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.0-beta.3.tgz",
+      "integrity": "sha512-8IVesRi8uaEVN4ZpT23ffGC9luzh1CrnAJe2oPqtRmdO6E5MjEM00zGgyIvcQlpAmYN1Jxx03xUuv21RPgNXow==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@process-engine/external_task.repository.sequelize": "3.1.0-beta.1",
     "@process-engine/flow_node_instance.repository.sequelize": "10.2.0-beta.1",
     "@process-engine/flow_node_instance.service": "1.2.0-beta.1",
-    "@process-engine/iam": "betafix~cache_by_token_instead_of_user_id",
+    "@process-engine/iam": "1.7.0-beta.3",
     "@process-engine/logging_api_core": "1.1.0",
     "@process-engine/logging.repository.file_system": "1.3.0",
     "@process-engine/management_api_core": "6.1.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@process-engine/external_task.repository.sequelize": "3.1.0-beta.1",
     "@process-engine/flow_node_instance.repository.sequelize": "10.2.0-beta.1",
     "@process-engine/flow_node_instance.service": "1.2.0-beta.1",
-    "@process-engine/iam": "1.7.0-beta.1",
+    "@process-engine/iam": "betafix~cache_by_token_instead_of_user_id",
     "@process-engine/logging_api_core": "1.1.0",
     "@process-engine/logging.repository.file_system": "1.3.0",
     "@process-engine/management_api_core": "6.1.0-beta.1",


### PR DESCRIPTION
## Changes

1. Reduce log spamming, when using test environments
2. Store claim check results by a users token, instead of a userId

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/419

PR: #420

## How to test the changes

- Make claim check requests for the same user, using different tokens with varying permissions
- See that the results are all correct