### PR TITLE
🐛 Terminate runtime when the bootstrapper fails to start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -920,9 +920,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.138",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
-      "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
+      "version": "4.14.139",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.139.tgz",
+      "integrity": "sha512-Z6pbDYaWpluqcF8+6qgv6STPEl0jIlyQmpYGwTrzhgwqok8ltBh/p7GAmYnz81wUhxQRhEr8MBpQrB4fQ/hwIA==",
       "dev": true
     },
     "@types/mime": {
@@ -937,9 +937,9 @@
       "dev": true
     },
     "@types/mongodb": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.2.tgz",
-      "integrity": "sha512-YTTzii2ECx+4R8kzKchydG905z3gb+lzrizeC4s8SAGan7/22bDDJ6nN6r9mueJGRGrCnFo1QBAI/Wz45lETZQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.3.tgz",
+      "integrity": "sha512-ymI6OZB4kqaSgLDFn7PYGNC+BmwbKPuw88F+gr9SGyAltcSKI6nYf+rj8hrHEsypnjtT5rA+dnmjXdPSgXgSgQ==",
       "dev": true,
       "requires": {
         "@types/bson": "*",
@@ -3272,9 +3272,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.1.tgz",
-      "integrity": "sha512-bqPIlDk06UWbVEIFoYj+LVo42WhK96J+b25l7hbFDpxrOXMphFM3fNIm+cluwg4Pk2jiLjWU5nHQY7igGE75NQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
+      "integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -4335,9 +4335,9 @@
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "minipass": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.1.tgz",
-      "integrity": "sha512-QCG523ParRcE2+9A6wYh9UI3uy2FFLw4DQaVYQrY5HPfszc5M6VDD+j0QCwHm19LI2imes4RB+NBD8cOJccyCg==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.5.tgz",
+      "integrity": "sha512-D5+szmZBoOAfbLjOXY4Ve5bWylyTdrUOmbJPgYmgTF5ovCnCFFTY+I16Ccm/UjSNNAekXtIEDvoCDioFzRz18Q==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,6 +165,7 @@ async function startProcessEngine(): Promise<void> {
 
   } catch (error) {
     logger.error('Bootstrapper failed to start.', error);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Changes

Bootstrapper errors will now cause the runtime to exit with an error.

## Issues

Closes #423

PR: #424

## How to test the changes

- Delete some of your configs or register something invalid at the ioc container
- Start up the runtime
- See that the bootstrapper throws an error and the process exits with error code 1