### PR TITLE
👷 📦 Attach ready-to-use platform specific sources to releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -26,3 +26,7 @@ node_modules
 .classpath
 .project
 .settings/
+
+Dockerfile
+Jenkinsfile
+.github

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,7 +268,7 @@ pipeline {
                 script {
                   echo('Creating zip from compiled sources')
                   // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
-                  powershell('Compress-Archive -Path bin, bpmn, config, dist, node_modules, scripts, sequelize, src, test, .eslintignore, .eslintrc, LICENSE, package-lock.json, package.json, README.md, reinstall.sh, tsconfig.json -CompressionLevel Fastest -DestinationPath process_engine_runtime_windows.zip')
+                  powershell('Compress-Archive -Path bin, bpmn, config, dist, node_modules, scripts, sequelize, src, test, .eslintignore, .eslintrc, LICENSE, package-lock.json, package.json, README.md, reinstall.sh, tsconfig.json -CompressionLevel NoCompression -DestinationPath process_engine_runtime_windows.zip')
 
                   stash(includes: 'process_engine_runtime_windows.zip', name: 'windows_application_package');
                   archiveArtifacts('process_engine_runtime_windows.zip')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,9 +268,10 @@ pipeline {
                 script {
                   echo('Creating zip from compiled sources')
                   // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
-                  bat('tar -czvf process_engine_runtime_linux.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock package.json README.md reinstall.sh tsconfig.json')
+                  powershell('Compress-Archive -Path bin, bpmn, config, dist, node_modules, scripts, sequelize, src, test, .eslintignore, .eslintrc, LICENSE, package-lock.json, package.json, README.md, reinstall.sh, tsconfig.json -CompressionLevel Optimal -DestinationPath process_engine_runtime_windows.zip')
 
-                  stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
+                  stash(includes: 'process_engine_runtime_windows.zip', name: 'windows_application_package');
+                  archiveArtifacts('process_engine_runtime_windows.zip')
                 }
               }
             }
@@ -547,13 +548,14 @@ pipeline {
                 unstash('windows_installer_results')
                 unstash('linux_application_package');
                 unstash('macos_application_package');
+                unstash('windows_application_package');
 
                 withCredentials([
                   usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
                 ]) {
                   sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
                   sh("""
-                  node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" process_engine_runtime_macos.tar.gz process_engine_runtime_linux.tar.gz
+                  node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" process_engine_runtime_macos.tar.gz process_engine_runtime_linux.tar.gz process_engine_runtime_windows.zip
                   """);
                 }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,8 +160,7 @@ pipeline {
                   sh('npm run build')
                   sh('npm rebuild')
                 }
-
-                stash(includes: '*, **/**', name: 'post_build_linux');
+                stash(includes: '*, **/**', name: 'linux_sources');
               }
             }
           }
@@ -191,8 +190,6 @@ pipeline {
                   sh('npm run build')
                   sh('npm rebuild')
                 }
-
-                stash(includes: '*, **/**', name: 'post_build_macos');
               }
             }
           }
@@ -224,8 +221,6 @@ pipeline {
                   bat('npm run build')
                   bat('npm rebuild')
                 }
-
-                stash(includes: '*, **/**', name: 'post_build_windows');
               }
             }
           }
@@ -245,7 +240,7 @@ pipeline {
             skipDefaultCheckout()
           }
           steps {
-            unstash('post_build_linux');
+            unstash('linux_sources');
 
             script {
               def mysql_host = "db";
@@ -302,7 +297,7 @@ pipeline {
             skipDefaultCheckout()
           }
           steps {
-            unstash('post_build_linux');
+            unstash('linux_sources');
 
             script {
               def postgres_host = "postgres";
@@ -358,7 +353,7 @@ pipeline {
             skipDefaultCheckout()
           }
           steps {
-            unstash('post_build_linux');
+            unstash('linux_sources');
 
             script {
               def node_env = 'NODE_ENV=test-sqlite';
@@ -456,8 +451,6 @@ pipeline {
           // Creates a tag from the current version and commits that tag.
           sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
         }
-
-        stash(includes: 'package.json', name: 'package_json')
       }
     }
     stage('Publish') {
@@ -472,7 +465,7 @@ pipeline {
             }
           }
           steps {
-            unstash('post_build_linux')
+            unstash('linux_sources')
             unstash('package_json')
 
             nodejs(configId: env.NPM_RC_FILE, nodeJSInstallationName: env.NODE_JS_VERSION) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -564,12 +564,13 @@ pipeline {
         withCredentials([
           usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
         ]) {
-          sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
+          //sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
           // sh("""
-          // node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" process_engine_runtime_macos.tar.gz process_engine_runtime_linux.tar.gz process_engine_runtime_windows.zip
+          // node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" "process_engine_runtime_macos.tar.gz" "process_engine_runtime_linux.tar.gz" "process_engine_runtime_windows.zip"
           // """);
+          sh('node ./node_modules/.bin/ci_tools update-github-release --use-title-and-text-from-git-tag');
           sh("""
-          node ./node_modules/.bin/ci_tools update-github-release --assets process_engine_runtime_macos.tar.gz process_engine_runtime_linux.tar.gz
+          node ./node_modules/.bin/ci_tools update-github-release --assets "process_engine_runtime_macos.tar.gz" "process_engine_runtime_linux.tar.gz"
           """);
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -477,27 +477,33 @@ pipeline {
         stage('Create tarball from linux sources') {
           agent {label 'linux'}
           steps {
-            unstash('linux_sources');
-            script {
-              echo('Creating tarball from compiled sources')
-              sh('tar -czvf process_engine_runtime_linux.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
+            sh('mkdir linux_sources')
+            dir('linux_sources') {
+              unstash('linux_sources');
+              script {
+                echo('Creating tarball from compiled sources')
+                sh('tar -czvf process_engine_runtime_linux.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
 
-              stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
-              archiveArtifacts('process_engine_runtime_linux.tar.gz')
+                stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
+                archiveArtifacts('process_engine_runtime_linux.tar.gz')
+              }
             }
           }
         }
         stage('Create tarball from macos sources') {
           agent {label 'macos'}
           steps {
-            unstash('macos_sources');
-            script {
-              sh('pwd')
-              echo('Creating tarball from compiled sources')
-              sh('tar -czvf process_engine_runtime_macos.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
+            sh('mkdir macos_sources')
+            dir('macos_sources') {
+              unstash('macos_sources');
+              script {
+                sh('pwd')
+                echo('Creating tarball from compiled sources')
+                sh('tar -czvf process_engine_runtime_macos.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
 
-              stash(includes: 'process_engine_runtime_macos.tar.gz', name: 'macos_application_package');
-              archiveArtifacts('process_engine_runtime_macos.tar.gz')
+                stash(includes: 'process_engine_runtime_macos.tar.gz', name: 'macos_application_package');
+                archiveArtifacts('process_engine_runtime_macos.tar.gz')
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,7 +246,8 @@ pipeline {
     }
     stage('Process Engine Runtime Tests') {
       when {
-        expression {buildIsRequired == true}
+        // expression {buildIsRequired == true}
+        expression {false == true}
       }
       parallel {
         stage('MySQL') {
@@ -384,7 +385,8 @@ pipeline {
     }
     stage('Check test results & notify Slack') {
       when {
-        expression {buildIsRequired == true}
+        // expression {buildIsRequired == true}
+        expression {false == true}
       }
       steps {
         script {
@@ -426,12 +428,12 @@ pipeline {
       when {
         allOf {
           expression {buildIsRequired == true}
-          expression {currentBuild.result == 'SUCCESS'}
-          anyOf {
-            branch "master"
-            branch "beta"
-            branch "develop"
-          }
+          // expression {currentBuild.result == 'SUCCESS'}
+          // anyOf {
+          //   branch "master"
+          //   branch "beta"
+          //   branch "develop"
+          // }
         }
       }
       steps {
@@ -439,7 +441,7 @@ pipeline {
           usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
         ]) {
           // Creates a tag from the current version and commits that tag.
-          sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
+          sh('node ./node_modules/.bin/ci_tools commit-and-tag-version')
         }
       }
     }
@@ -447,7 +449,7 @@ pipeline {
       when {
         allOf {
           expression {buildIsRequired == true}
-          expression {currentBuild.result == 'SUCCESS'}
+          // expression {currentBuild.result == 'SUCCESS'}
         }
       }
       steps {
@@ -463,12 +465,12 @@ pipeline {
       when {
         allOf {
           expression {buildIsRequired == true}
-          expression {currentBuild.result == 'SUCCESS'}
-          anyOf {
-            branch "master"
-            branch "beta"
-            branch "develop"
-          }
+          // expression {currentBuild.result == 'SUCCESS'}
+          // anyOf {
+          //   branch "master"
+          //   branch "beta"
+          //   branch "develop"
+          // }
         }
       }
       parallel {
@@ -517,37 +519,37 @@ pipeline {
             }
           }
         }
-        stage('Build Windows Installer') {
-          agent {label 'windows'}
-          steps {
-            unstash('package_json')
+        // stage('Build Windows Installer') {
+        //   agent {label 'windows'}
+        //   steps {
+        //     unstash('package_json')
 
-            nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
-              unstash('windows_sources');
-              bat('npm run build-windows-executable')
-            }
+        //     nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
+        //       unstash('windows_sources');
+        //       bat('npm run build-windows-executable')
+        //     }
 
-            bat("$INNO_SETUP_ISCC /DProcessEngineRuntimeVersion=$full_release_version_string installer\\inno-installer.iss")
+        //     bat("$INNO_SETUP_ISCC /DProcessEngineRuntimeVersion=$full_release_version_string installer\\inno-installer.iss")
 
-            stash(includes: "installer\\Output\\*.exe", name: 'windows_installer_results')
-          }
-        }
+        //     stash(includes: "installer\\Output\\*.exe", name: 'windows_installer_results')
+        //   }
+        // }
       }
     }
     stage('Publish GitHub Release') {
       when {
         allOf {
           expression {buildIsRequired == true}
-          expression {currentBuild.result == 'SUCCESS'}
-          anyOf {
-            branch "master"
-            branch "beta"
-            branch "develop"
-          }
+          // expression {currentBuild.result == 'SUCCESS'}
+          // anyOf {
+          //   branch "master"
+          //   branch "beta"
+          //   branch "develop"
+          // }
         }
       }
       steps {
-        unstash('windows_installer_results')
+        // unstash('windows_installer_results')
         unstash('linux_application_package');
         unstash('macos_application_package');
         unstash('windows_application_package');
@@ -555,9 +557,12 @@ pipeline {
         withCredentials([
           usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
         ]) {
-          sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
+          sh('node ./node_modules/.bin/ci_tools update-github-release --use-title-and-text-from-git-tag');
+          // sh("""
+          // node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" --assets process_engine_runtime_macos.tar.gz --assets process_engine_runtime_linux.tar.gz --assets process_engine_runtime_windows.zip
+          // """);
           sh("""
-          node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" --assets process_engine_runtime_macos.tar.gz --assets process_engine_runtime_linux.tar.gz --assets process_engine_runtime_windows.zip
+          node ./node_modules/.bin/ci_tools update-github-release --assets process_engine_runtime_macos.tar.gz --assets process_engine_runtime_linux.tar.gz --assets process_engine_runtime_windows.zip
           """);
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -482,7 +482,9 @@ pipeline {
               unstash('linux_sources');
               script {
                 echo('Creating tarball from compiled sources')
-                sh('tar -czvf process_engine_runtime_linux.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
+                sh('tar -czvf process_engine_runtime_linux.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
+                // TODO: For some reason, this causes a "tar: .: file changed as we read it" error
+                // sh('tar -czvf process_engine_runtime_linux.tar.gz --exclude=\'.git*\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' --exclude=\'.npmignore\' .')
 
                 stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
                 archiveArtifacts('process_engine_runtime_linux.tar.gz')
@@ -499,7 +501,7 @@ pipeline {
               script {
                 sh('pwd')
                 echo('Creating tarball from compiled sources')
-                sh('tar -czvf process_engine_runtime_macos.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
+                sh('tar -czvf process_engine_runtime_macos.tar.gz --exclude=\'.git*\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' --exclude=\'.npmignore\' .')
 
                 stash(includes: 'process_engine_runtime_macos.tar.gz', name: 'macos_application_package');
                 archiveArtifacts('process_engine_runtime_macos.tar.gz')
@@ -518,7 +520,7 @@ pipeline {
               echo('Creating zip from compiled sources')
               unstash('windows_sources');
 
-              sh('zip -r process_engine_runtime_windows.zip --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
+              sh('zip -r process_engine_runtime_windows.zip --exclude=\'.git*\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' --exclude=\'.npmignore\' .')
 
               stash(includes: 'process_engine_runtime_windows.zip', name: 'windows_application_package');
               archiveArtifacts('process_engine_runtime_windows.zip')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,8 +247,7 @@ pipeline {
     }
     stage('Process Engine Runtime Tests') {
       when {
-        // expression {buildIsRequired == true}
-        expression {false == true}
+        expression {buildIsRequired == true}
       }
       parallel {
         stage('MySQL') {
@@ -386,8 +385,7 @@ pipeline {
     }
     stage('Check test results & notify Slack') {
       when {
-        // expression {buildIsRequired == true}
-        expression {false == true}
+        expression {buildIsRequired == true}
       }
       steps {
         script {
@@ -429,12 +427,12 @@ pipeline {
       when {
         allOf {
           expression {buildIsRequired == true}
-          // expression {currentBuild.result == 'SUCCESS'}
-          // anyOf {
-          //   branch "master"
-          //   branch "beta"
-          //   branch "develop"
-          // }
+          expression {currentBuild.result == 'SUCCESS'}
+          anyOf {
+            branch "master"
+            branch "beta"
+            branch "develop"
+          }
         }
       }
       steps {
@@ -442,7 +440,7 @@ pipeline {
           usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
         ]) {
           // Creates a tag from the current version and commits that tag.
-          sh('node ./node_modules/.bin/ci_tools commit-and-tag-version')
+          sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
         }
       }
     }
@@ -450,7 +448,7 @@ pipeline {
       when {
         allOf {
           expression {buildIsRequired == true}
-          // expression {currentBuild.result == 'SUCCESS'}
+          expression {currentBuild.result == 'SUCCESS'}
         }
       }
       steps {
@@ -466,12 +464,12 @@ pipeline {
       when {
         allOf {
           expression {buildIsRequired == true}
-          // expression {currentBuild.result == 'SUCCESS'}
-          // anyOf {
-          //   branch "master"
-          //   branch "beta"
-          //   branch "develop"
-          // }
+          expression {currentBuild.result == 'SUCCESS'}
+          anyOf {
+            branch "master"
+            branch "beta"
+            branch "develop"
+          }
         }
       }
       parallel {
@@ -529,37 +527,37 @@ pipeline {
             }
           }
         }
-        // stage('Build Windows Installer') {
-        //   agent {label 'windows'}
-        //   steps {
-        //     unstash('package_json')
+        stage('Build Windows Installer') {
+          agent {label 'windows'}
+          steps {
+            unstash('package_json')
 
-        //     nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
-        //       unstash('windows_sources');
-        //       bat('npm run build-windows-executable')
-        //     }
+            nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
+              unstash('windows_sources');
+              bat('npm run build-windows-executable')
+            }
 
-        //     bat("$INNO_SETUP_ISCC /DProcessEngineRuntimeVersion=$full_release_version_string installer\\inno-installer.iss")
+            bat("$INNO_SETUP_ISCC /DProcessEngineRuntimeVersion=$full_release_version_string installer\\inno-installer.iss")
 
-        //     stash(includes: "installer\\Output\\*.exe", name: 'windows_installer_results')
-        //   }
-        // }
+            stash(includes: "installer\\Output\\*.exe", name: 'windows_installer_results')
+          }
+        }
       }
     }
     stage('Publish GitHub Release') {
       when {
         allOf {
           expression {buildIsRequired == true}
-          // expression {currentBuild.result == 'SUCCESS'}
-          // anyOf {
-          //   branch "master"
-          //   branch "beta"
-          //   branch "develop"
-          // }
+          expression {currentBuild.result == 'SUCCESS'}
+          anyOf {
+            branch "master"
+            branch "beta"
+            branch "develop"
+          }
         }
       }
       steps {
-        // unstash('windows_installer_results')
+        unstash('windows_installer_results')
         unstash('linux_application_package');
         unstash('macos_application_package');
         unstash('windows_application_package');
@@ -567,12 +565,9 @@ pipeline {
         withCredentials([
           usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
         ]) {
-          sh('node ./node_modules/.bin/ci_tools update-github-release --use-title-and-text-from-git-tag');
-          // sh("""
-          // node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" --assets process_engine_runtime_macos.tar.gz --assets process_engine_runtime_linux.tar.gz --assets process_engine_runtime_windows.zip
-          // """);
+          sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
           sh("""
-          node ./node_modules/.bin/ci_tools update-github-release --assets process_engine_runtime_macos.tar.gz --assets process_engine_runtime_linux.tar.gz --assets process_engine_runtime_windows.zip
+          node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" --assets process_engine_runtime_macos.tar.gz --assets process_engine_runtime_linux.tar.gz --assets process_engine_runtime_windows.zip
           """);
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -524,7 +524,7 @@ pipeline {
 
             nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
               unstash('windows_sources');
-              bat('npm run create-executable-windows')
+              bat('npm run build-windows-executable')
             }
 
             bat("$INNO_SETUP_ISCC /DProcessEngineRuntimeVersion=$full_release_version_string installer\\inno-installer.iss")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -510,6 +510,7 @@ pipeline {
           steps {
             unstash('macos_sources');
             script {
+              sh('pwd')
               echo('Creating tarball from compiled sources')
               // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
               sh('tar -czvf process_engine_runtime_macos.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
@@ -529,11 +530,14 @@ pipeline {
             // To prevent collision with the 'Create tarball from macos sources' step, we do this in a subfolder.
             sh('mkdir windows_sources')
             dir('windows_sources') {
+              sh('pwd')
               echo('Creating zip from compiled sources')
               unstash('windows_sources');
 
+              sh('ls -lahS .')
+
               // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
-              sh('zip process_engine_runtime_windows.zip bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
+              sh('zip -r process_engine_runtime_windows.zip bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
 
               stash(includes: 'process_engine_runtime_windows.zip', name: 'windows_application_package');
               archiveArtifacts('process_engine_runtime_windows.zip')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,7 +268,7 @@ pipeline {
                 script {
                   echo('Creating zip from compiled sources')
                   // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
-                  powershell('Compress-Archive -Path bin, bpmn, config, dist, node_modules, scripts, sequelize, src, test, .eslintignore, .eslintrc, LICENSE, package-lock.json, package.json, README.md, reinstall.sh, tsconfig.json -CompressionLevel Optimal -DestinationPath process_engine_runtime_windows.zip')
+                  powershell('Compress-Archive -Path bin, bpmn, config, dist, node_modules, scripts, sequelize, src, test, .eslintignore, .eslintrc, LICENSE, package-lock.json, package.json, README.md, reinstall.sh, tsconfig.json -CompressionLevel Fastest -DestinationPath process_engine_runtime_windows.zip')
 
                   stash(includes: 'process_engine_runtime_windows.zip', name: 'windows_application_package');
                   archiveArtifacts('process_engine_runtime_windows.zip')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
 
           // TODO: variable `full_release_version_string` is still needed for windows release stage
           script {
-            raw_package_version = bat(script: 'node --print --eval "require(\'./package.json\').version"', returnStdout: true)
+            raw_package_version = sh(script: 'node --print --eval "require(\'./package.json\').version"', returnStdout: true)
             full_release_version_string = raw_package_version.trim()
             echo("full_release_version_string is '${full_release_version_string}'")
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -453,17 +453,18 @@ pipeline {
           usernamePassword(credentialsId: 'process-engine-ci_github-token', passwordVariable: 'GH_TOKEN', usernameVariable: 'GH_USER')
         ]) {
           // Creates a tag from the current version and commits that tag.
-          sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
+          // sh('node ./node_modules/.bin/ci_tools commit-and-tag-version --only-on-primary-branches')
+          sh('node ./node_modules/.bin/ci_tools commit-and-tag-version')
         }
       }
     }
     stage('Publish to npm') {
-      when {
-        allOf {
-          expression {buildIsRequired == true}
-          expression { currentBuild.result == 'SUCCESS'}
-        }
-      }
+      // when {
+      //   allOf {
+      //     expression {buildIsRequired == true}
+      //     expression { currentBuild.result == 'SUCCESS'}
+      //   }
+      // }
       steps {
         unstash('linux_sources')
         unstash('package_json')
@@ -555,6 +556,17 @@ pipeline {
       }
     }
     stage('Publish GitHub Release') {
+      when {
+        allOf {
+          expression {buildIsRequired == true}
+          // expression {currentBuild.result == 'SUCCESS'}
+          // anyOf {
+          //   branch "master"
+          //   branch "beta"
+          //   branch "develop"
+          // }
+        }
+      }
       steps {
         // unstash('windows_installer_results')
         unstash('linux_application_package');
@@ -566,11 +578,12 @@ pipeline {
         ]) {
           //sh('node ./node_modules/.bin/ci_tools update-github-release --only-on-primary-branches --use-title-and-text-from-git-tag');
           // sh("""
-          // node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" "process_engine_runtime_macos.tar.gz" "process_engine_runtime_linux.tar.gz" "process_engine_runtime_windows.zip"
+          // node ./node_modules/.bin/ci_tools update-github-release --assets "installer/Output/*.exe" --assets "process_engine_runtime_macos.tar.gz" --assets "process_engine_runtime_linux.tar.gz" --assets "process_engine_runtime_windows.zip"
           // """);
+          sh('ls -laih')
           sh('node ./node_modules/.bin/ci_tools update-github-release --use-title-and-text-from-git-tag');
           sh("""
-          node ./node_modules/.bin/ci_tools update-github-release --assets "process_engine_runtime_macos.tar.gz" "process_engine_runtime_linux.tar.gz"
+          node ./node_modules/.bin/ci_tools update-github-release --assets process_engine_runtime_macos.tar.gz --assets process_engine_runtime_linux.tar.gz
           """);
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,12 +94,13 @@ pipeline {
           sh 'git --no-pager show -s --format=\'%an\' > commit-author.txt'
           def commitAuthorName = readFile('commit-author.txt').trim()
 
-          def ciUserName = "admin"
+          def ciAdminName = "admin" // jenkins will set this name after every restart, so we need to look out for this.
+          def ciUserName = "process-engine-ci"
 
           echo(commitAuthorName)
           echo("Commiter is process-engine-ci: ${commitAuthorName == ciUserName}")
 
-          buildIsRequired = commitAuthorName != ciUserName
+          buildIsRequired = commitAuthorName != ciAdminName && commitAuthorName != ciUserName
 
           if (!buildIsRequired) {
             echo("Commit was made by process-engine-ci. Skipping build.")
@@ -484,6 +485,7 @@ pipeline {
                 echo('Creating tarball from compiled sources')
                 sh('tar -czvf process_engine_runtime_linux.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
                 // TODO: For some reason, this causes a "tar: .: file changed as we read it" error
+                // Only seems to happen for the linux sources.
                 // sh('tar -czvf process_engine_runtime_linux.tar.gz --exclude=\'.git*\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' --exclude=\'.npmignore\' .')
 
                 stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -478,7 +478,7 @@ pipeline {
             unstash('linux_sources');
             script {
               echo('Creating tarball from compiled sources')
-              sh('tar -czvf process_engine_runtime_linux.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
+              sh('tar -czvf process_engine_runtime_linux.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
 
               stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
               archiveArtifacts('process_engine_runtime_linux.tar.gz')
@@ -492,7 +492,7 @@ pipeline {
             script {
               sh('pwd')
               echo('Creating tarball from compiled sources')
-              sh('tar -czvf process_engine_runtime_macos.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
+              sh('tar -czvf process_engine_runtime_macos.tar.gz --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
 
               stash(includes: 'process_engine_runtime_macos.tar.gz', name: 'macos_application_package');
               archiveArtifacts('process_engine_runtime_macos.tar.gz')
@@ -510,7 +510,7 @@ pipeline {
               echo('Creating zip from compiled sources')
               unstash('windows_sources');
 
-              sh('zip -r process_engine_runtime_windows.zip bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
+              sh('zip -r process_engine_runtime_windows.zip --exclude=\'.git\' --exclude=\'.github\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' .')
 
               stash(includes: 'process_engine_runtime_windows.zip', name: 'windows_application_package');
               archiveArtifacts('process_engine_runtime_windows.zip')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,6 +160,13 @@ pipeline {
                   sh('npm run build')
                   sh('npm rebuild')
                 }
+              }
+            }
+            stage('stash sources for integrationtests') {
+              when {
+                expression {buildIsRequired == true}
+              }
+              steps {
                 stash(includes: '*, **/**', name: 'linux_sources');
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -113,6 +113,8 @@ pipeline {
       }
       steps {
         nodejs(configId: NPM_RC_FILE, nodeJSInstallationName: NODE_JS_VERSION) {
+          // ci_tools must be installed for the scripts to work.
+          sh('npm install @process-engine/ci_tools')
           // Prepares the new version (alpha, beta, stable), but does not yet commit it.
           sh('node ./node_modules/.bin/ci_tools prepare-version --allow-dirty-workdir')
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -478,7 +478,6 @@ pipeline {
             unstash('linux_sources');
             script {
               echo('Creating tarball from compiled sources')
-              // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
               sh('tar -czvf process_engine_runtime_linux.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
 
               stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
@@ -493,7 +492,6 @@ pipeline {
             script {
               sh('pwd')
               echo('Creating tarball from compiled sources')
-              // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
               sh('tar -czvf process_engine_runtime_macos.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
 
               stash(includes: 'process_engine_runtime_macos.tar.gz', name: 'macos_application_package');
@@ -512,7 +510,6 @@ pipeline {
               echo('Creating zip from compiled sources')
               unstash('windows_sources');
 
-              // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
               sh('zip -r process_engine_runtime_windows.zip bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json')
 
               stash(includes: 'process_engine_runtime_windows.zip', name: 'windows_application_package');

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -260,20 +260,20 @@ pipeline {
                 }
               }
             }
-            // stage('Create zipfile from sources') {
-            //   when {
-            //     expression {buildIsRequired == true}
-            //   }
-            //   steps {
-            //     script {
-            //       echo('Creating zip from compiled sources')
-            //       // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
-            //       bat('tar -czvf process_engine_runtime_linux.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock package.json README.md reinstall.sh tsconfig.json')
+            stage('Create zipfile from sources') {
+              when {
+                expression {buildIsRequired == true}
+              }
+              steps {
+                script {
+                  echo('Creating zip from compiled sources')
+                  // Excludes the following files and folders: .git, .github, .gitignore, .npmignore, Dockerfile, Jenkinsfile
+                  bat('tar -czvf process_engine_runtime_linux.tar.gz bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock package.json README.md reinstall.sh tsconfig.json')
 
-            //       stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
-            //     }
-            //   }
-            // }
+                  stash(includes: 'process_engine_runtime_linux.tar.gz', name: 'linux_application_package');
+                }
+              }
+            }
           }
         }
       }
@@ -633,14 +633,14 @@ pipeline {
           agent {label 'master'}
           steps {
             script {
-              sh(script: ':', returnStdout: true);
+              echo('Cleaning up master');
             }
           }
-        }
-        post {
-          always {
-            script {
-              cleanup_workspace();
+          post {
+            always {
+              script {
+                cleanup_workspace();
+              }
             }
           }
         }
@@ -648,14 +648,14 @@ pipeline {
           agent {label 'macos'}
           steps {
             script {
-              sh(script: ':', returnStdout: true);
+              echo('Cleaning up macos slave');
             }
           }
-        }
-        post {
-          always {
-            script {
-              cleanup_workspace();
+          post {
+            always {
+              script {
+                cleanup_workspace();
+              }
             }
           }
         }
@@ -663,29 +663,31 @@ pipeline {
           agent {label 'windows'}
           steps {
             script {
-              sh(script: ':', returnStdout: true);
+              echo('Cleaning up windows slave');
+            }
+          }
+          post {
+            always {
+              script {
+                cleanup_workspace();
+              }
             }
           }
         }
-        post {
-          always {
-            script {
-              cleanup_workspace();
-            }
-          }
-        }
-        stage('linux slaves') {
+        stage('linux slave') {
+          // Note that there are actually two slaves with that label.
+          // So it CAN happen, that this will not run on the actual slave that was used by the integration tests.
           agent {label 'process-engine-tests'}
           steps {
             script {
-              sh(script: ':', returnStdout: true);
+              echo('Cleaning up linux integrationtest slave');
             }
           }
-        }
-        post {
-          always {
-            script {
-              cleanup_workspace();
+          post {
+            always {
+              script {
+                cleanup_workspace();
+              }
             }
           }
         }

--- a/installer/README.md
+++ b/installer/README.md
@@ -22,7 +22,7 @@ Create a windows installer for the ProcessEngine Runtime.
 1. Create an executable file from the runtime:
 
     ```bat
-    npm run create-executable-windows
+    npm run build-windows-executable
     ```
 
     This script will use `pkg` to create the `process_engine_runtime.exe`

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,9 +820,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-          "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
+          "version": "12.7.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.7.tgz",
+          "integrity": "sha512-4jUncNe2tj1nmrO/34PsRpZqYVnRV1svbU78cKhuQKkMntKB/AmdLyGgswcZKjFHEHGpiY8pVD8CuVI55nP54w=="
         }
       }
     },
@@ -849,9 +849,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-          "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
+          "version": "12.7.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.7.tgz",
+          "integrity": "sha512-4jUncNe2tj1nmrO/34PsRpZqYVnRV1svbU78cKhuQKkMntKB/AmdLyGgswcZKjFHEHGpiY8pVD8CuVI55nP54w=="
         }
       }
     },
@@ -896,9 +896,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-          "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
+          "version": "12.7.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.7.tgz",
+          "integrity": "sha512-4jUncNe2tj1nmrO/34PsRpZqYVnRV1svbU78cKhuQKkMntKB/AmdLyGgswcZKjFHEHGpiY8pVD8CuVI55nP54w=="
         }
       }
     },
@@ -947,9 +947,9 @@
       }
     },
     "@types/node": {
-      "version": "10.14.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
-      "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ=="
+      "version": "10.14.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.19.tgz",
+      "integrity": "sha512-j6Sqt38ssdMKutXBUuAcmWF8QtHW1Fwz/mz4Y+Wd9mzpBiVFirjpNQf363hG5itkG+yGaD+oiLyb50HxJ36l9Q=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -978,17 +978,17 @@
       }
     },
     "@types/socket.io": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.2.tgz",
-      "integrity": "sha512-Ind+4qMNfQ62llyB4IMs1D8znMEBsMKohZBPqfBUIXqLQ9bdtWIbNTBWwtdcBWJKnokMZGcmWOOKslatni5vtA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.3.tgz",
+      "integrity": "sha512-TfgFyiGkXATFfJNjkC/+qtPbVpLBIZkSKYV3cs/i0KoOiklltcGbvRFif9zWVYC10dyaU91RV3CMdiDLub2nbQ==",
       "requires": {
         "@types/node": "*"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.7.5",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-          "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
+          "version": "12.7.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.7.tgz",
+          "integrity": "sha512-4jUncNe2tj1nmrO/34PsRpZqYVnRV1svbU78cKhuQKkMntKB/AmdLyGgswcZKjFHEHGpiY8pVD8CuVI55nP54w=="
         }
       }
     },
@@ -1616,9 +1616,9 @@
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "chownr": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
-      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -2136,9 +2136,9 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.2.tgz",
-      "integrity": "sha512-gUSUszrsxlDnUbUwEI9Oygyrk4ZEWtVaHQc+uZHphVeNxl+qeqMV/jDWoTkjN1RmGlZ5QWAP7o458p/JMlikQg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.3.tgz",
+      "integrity": "sha512-cbNhPFS6MlYlWTGncSiDYbdqKhwWFy7kNeb1YSOG6K65i/wPTkLVCJQj0hXA4j0m5Da+hBWnqopEnu1FFelisQ==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
@@ -3272,9 +3272,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
-      "integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -4335,9 +4335,9 @@
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "minipass": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.5.tgz",
-      "integrity": "sha512-D5+szmZBoOAfbLjOXY4Ve5bWylyTdrUOmbJPgYmgTF5ovCnCFFTY+I16Ccm/UjSNNAekXtIEDvoCDioFzRz18Q==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.8.6.tgz",
+      "integrity": "sha512-lFG7d6g3+/UaFDCOtqPiKAC9zngWWsQZl1g5q6gaONqrjq61SX2xFqXMleQiFVyDpYwa018E9hmlAFY22PCb+A==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -6701,13 +6701,13 @@
       }
     },
     "tar": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.11.tgz",
-      "integrity": "sha512-iI4zh3ktLJKaDNZKZc+fUONiQrSn9HkCFzamtb7k8FFmVilHVob7QsLX/VySAW8lAviMzMbFw4QtFb4errwgYA==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
       "requires": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
-        "minipass": "^2.6.4",
+        "minipass": "^2.8.6",
         "minizlib": "^1.2.1",
         "mkdirp": "^0.5.0",
         "safe-buffer": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "npm run test-sqlite",
     "test-all": "npm run test-sqlite && npm run test-postgres",
     "test-debug": "cross-env NODE_ENV=test-sqlite CONFIG_PATH=config mocha --inspect-brk test/**/*.js test/**/**/*.js  --exit",
-    "create-executable-windows": "pkg --targets windows ."
+    "build-windows-executable": "pkg --targets windows ."
   },
   "main": "./dist/commonjs/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "test": "npm run test-sqlite",
     "test-all": "npm run test-sqlite && npm run test-postgres",
     "test-debug": "cross-env NODE_ENV=test-sqlite CONFIG_PATH=config mocha --inspect-brk test/**/*.js test/**/**/*.js  --exit",
-    "build-windows-executable": "pkg --targets windows ."
+    "build-windows-executable": "pkg --targets windows .",
+    "create-tarball": "node ./scripts/pack_sources/pack_to_tarball.js",
+    "create-zipfile": "node ./scripts/pack_sources/pack_to_zip.js"
   },
   "main": "./dist/commonjs/index.js",
   "license": "MIT",

--- a/scripts/pack_sources/exec_async.js
+++ b/scripts/pack_sources/exec_async.js
@@ -1,0 +1,16 @@
+const exec = require('child_process').exec;
+
+module.exports.execAsync = async(command) => {
+
+  return new Promise((resolve, reject) => {
+
+    exec(command, (error, stdout) => {
+
+      if (error) {
+        return reject(error);
+      }
+
+      return resolve(stdout);
+    });
+  });
+}

--- a/scripts/pack_sources/pack_to_tarball.js
+++ b/scripts/pack_sources/pack_to_tarball.js
@@ -1,0 +1,17 @@
+const exec = require('./exec_async').execAsync;
+const os = require('os');
+
+const packageName = os.platform() === 'darwin'
+  ? 'process_engine_runtime_macos.tar.gz'
+  : 'process_engine_runtime_linux.tar.gz'
+
+// TODO: For some reason, this causes a "tar: .: file changed as we read it" error, when Jenkins tries to pack the linux sources.
+// const tarballCommand = 'tar -czvf process_engine_runtime_macos.tar.gz --exclude=\'.git*\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' --exclude=\'.npmignore\' .';
+const tarballCommand = `tar -czf ${packageName} bin bpmn config dist node_modules scripts sequelize src test .eslintignore .eslintrc LICENSE package-lock.json package.json README.md reinstall.sh tsconfig.json`;
+
+exec(tarballCommand)
+  .then(() => console.log('Success!'))
+  .catch((error) => {
+    console.log(error);
+    process.exit(1);
+  });

--- a/scripts/pack_sources/pack_to_zip.js
+++ b/scripts/pack_sources/pack_to_zip.js
@@ -1,0 +1,10 @@
+const exec = require('./exec_async').execAsync;
+
+const zipCommand = 'zip -rq process_engine_runtime_windows.zip --exclude=\'.git*\' --exclude=\'Jenkinsfile\' --exclude=\'Dockerfile\' --exclude=\'.npmignore\' .';
+
+exec(zipCommand)
+  .then(() => console.log('Success!'))
+  .catch((error) => {
+    console.log(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Changes

1. `Prepare Version` now only prepares the version for the package.json
2. Installation and Build is now performed for all supported platforms (linux, macos and windows)
    - The results of which are stashed for later use
3. The source files created by the linux build are used as a base for the integrationtests (this is actually how it was done up until now)
4. Creating the .zip- and .tar.gz files is done in parallel to building the windows installer
5. GitHub Releases will now contain the .zip- and .tar.gz files, in addition to the windows installer.
6. Pushing to npm and github is now done in sequence, not in parallel anymore
    - The reason is simple: We cannot nest `parallel` statements. Attempting to do so breaks the CI. Since building all the parts for the GitHub release is far more time consuming, it makes more sense to parallelize those.
7. All cleanup work is now done by a final cleanup step that runs on all agents used during the build

## Issues

Closes #421

PR: #425

## How to test the changes

- Run some builds for the main branches (develop, beta, master)
- The releases created for those branches will now contain a .zip file for a ready-to-use ProcessEngineRuntime for windows, and .tar.gz files for MacOS and Linux

**NOTE:**

Zipping the windows files is actually performed on the MacOS slave, because using `Compress-Archive` on the windows slave takes over an hour to complete (yes, you read that one correctly). Zipping those files on any of the other slaves only takes a couple of seconds.
This actually works, because installing, building and rebuilding is done on the windows slave. The macos slave just uses the generated files from the windows slave to create the zipfile. 