### PR TITLE
✨ Add global routes with `process_engine` prefix

### DIFF
--- a/src/global_route_configurator.ts
+++ b/src/global_route_configurator.ts
@@ -9,8 +9,6 @@ let httpExtension: IHttpExtension;
 
 const httpStatusCodeSuccess = 200;
 
-const allowUseOfGlobalRoute = process.env.DO_NOT_BLOCK_GLOBAL_ROUTE === undefined;
-
 interface IApplicationInfo {
   name: string;
   version: string;
@@ -31,6 +29,8 @@ export async function configureGlobalRoutes(container: InvocationContainer): Pro
 }
 
 function configureRootRoute(): void {
+
+  const allowUseOfGlobalRoute = process.env.DO_NOT_BLOCK_GLOBAL_ROUTE === undefined;
   const packageInfo = getInfosFromPackageJson();
 
   const formattedResponse = JSON.stringify(packageInfo, undefined, 2);
@@ -54,6 +54,8 @@ function configureRootRoute(): void {
 }
 
 function configureAuthorityRoute(): void {
+
+  const allowUseOfGlobalRoute = process.env.DO_NOT_BLOCK_GLOBAL_ROUTE === undefined;
   const iamConfig = loadConfig('iam', 'iam_service');
 
   const responseBody = {
@@ -73,7 +75,7 @@ function configureAuthorityRoute(): void {
     });
   }
 
-  httpExtension.app.get(`/process_engine/${authorityRoute}`, (request: Request, response: Response): void => {
+  httpExtension.app.get(`/process_engine${authorityRoute}`, (request: Request, response: Response): void => {
     response
       .status(httpStatusCodeSuccess)
       .header('Content-Type', 'application/json')

--- a/src/global_route_configurator.ts
+++ b/src/global_route_configurator.ts
@@ -30,7 +30,7 @@ export async function configureGlobalRoutes(container: InvocationContainer): Pro
 
 function configureRootRoute(): void {
 
-  const allowUseOfGlobalRoute = process.env.DO_NOT_BLOCK_GLOBAL_ROUTE === undefined;
+  const allowUseOfGlobalRoute = !process.env.DO_NOT_BLOCK_GLOBAL_ROUTE;
   const packageInfo = getInfosFromPackageJson();
 
   const formattedResponse = JSON.stringify(packageInfo, undefined, 2);

--- a/test/0_global_routes/authority_route.js
+++ b/test/0_global_routes/authority_route.js
@@ -60,6 +60,23 @@ describe('Authority Route /security/authority - ', () => {
     }
   });
 
+  it(`Should return the address of the used authority, when the route with the 'process_engine' prefix is used`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    try {
+      const response = await httpClient.get(`process_engine/${routeToCall}`, requestHeaders);
+      assertResponse(response);
+    } catch (error) {
+      should.fail(error, 'success', `Failed to run the request: ${error.message}`);
+    }
+  });
+
+
   function assertResponse(response) {
 
     should(response.status).be.equal(200);

--- a/test/0_global_routes/do_not_block_global_route_flag.js
+++ b/test/0_global_routes/do_not_block_global_route_flag.js
@@ -27,7 +27,7 @@ describe('Main Route Sanity checks', () => {
     delete process.env.DO_NOT_BLOCK_GLOBAL_ROUTE;
   });
 
-  it(`Should block global route '/', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+  it(`Should disable '/' route, when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
 
     const requestHeaders = {
       headers: {
@@ -44,7 +44,7 @@ describe('Main Route Sanity checks', () => {
     }
   });
 
-  it(`Should block global route '/security/authority', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+  it(`Should disable '/security/authority' route, when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
 
     const requestHeaders = {
       headers: {
@@ -61,7 +61,7 @@ describe('Main Route Sanity checks', () => {
     }
   });
 
-  it(`Should not block global route '/process_engine', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+  it(`Should not disable '/process_engine' route, when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
 
     const requestHeaders = {
       headers: {
@@ -74,7 +74,7 @@ describe('Main Route Sanity checks', () => {
     should(response.status).be.equal(200);
   });
 
-  it(`Should not block global route '/process_engine/security/authority', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+  it(`Should not disable '/process_engine/ routesecurity/authority', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
 
     const requestHeaders = {
       headers: {

--- a/test/0_global_routes/main_route.js
+++ b/test/0_global_routes/main_route.js
@@ -60,7 +60,7 @@ describe('Main Route http://localhost:32413 - ', () => {
     }
   });
 
-  it(`Should return infos about the application, when the route with the 'process_engine' prefix is used`, async () => {
+  it(`Should return info about the application, when the route with the 'process_engine' prefix is used`, async () => {
 
     const requestHeaders = {
       headers: {

--- a/test/0_global_routes/main_route.js
+++ b/test/0_global_routes/main_route.js
@@ -60,6 +60,22 @@ describe('Main Route http://localhost:32413 - ', () => {
     }
   });
 
+  it(`Should return infos about the application, when the route with the 'process_engine' prefix is used`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    try {
+      const response = await httpClient.get(`process_engine/${routeToCall}`, requestHeaders);
+      assertResponse(response);
+    } catch (error) {
+      should.fail(error, 'success', `Failed to run the request: ${error.message}`);
+    }
+  });
+
   function assertResponse(response) {
 
     should(response.status).be.equal(200);

--- a/test/0_global_routes/sanity_checks.js
+++ b/test/0_global_routes/sanity_checks.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const should = require('should');
+const TestFixtureProvider = require('../../dist/commonjs/test_setup').TestFixtureProvider;
+
+const HttpClient = require('@essential-projects/http').HttpClient;
+
+describe('Main Route Sanity checks', () => {
+
+  let httpClient;
+
+  let testFixtureProvider;
+
+  before(async () => {
+    process.env.DO_NOT_BLOCK_GLOBAL_ROUTE = true;
+    testFixtureProvider = new TestFixtureProvider();
+    await testFixtureProvider.initializeAndStart();
+
+    httpClient = new HttpClient();
+    httpClient.config = {
+      url: 'http://localhost:32413',
+    };
+  });
+
+  after(async () => {
+    process.env.DO_NOT_BLOCK_GLOBAL_ROUTE = undefined;
+    await testFixtureProvider.tearDown();
+  });
+
+  it(`Should block global route '/', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    try {
+      const response = await httpClient.get('', requestHeaders);
+      should.fail(response, 'error', `This route should not be available!`);
+    } catch (error) {
+      should(error.code).be.equal(404);
+    }
+  });
+
+  it(`Should block global route '/security/authority', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    try {
+      const response = await httpClient.get('security/authority', requestHeaders);
+      should.fail(response, 'error', `This route should not be available!`);
+    } catch (error) {
+      should(error.code).be.equal(404);
+    }
+  });
+
+  it(`Should not block global route '/process_engine', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    const response = await httpClient.get('process_engine', requestHeaders);
+    should(response.status).be.equal(200);
+  });
+
+  it(`Should not block global route '/process_engine/security/authority', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    const response = await httpClient.get('process_engine/security/authority', requestHeaders);
+    should(response.status).be.equal(200);
+  });
+});

--- a/test/0_global_routes/sanity_checks.js
+++ b/test/0_global_routes/sanity_checks.js
@@ -23,8 +23,8 @@ describe('Main Route Sanity checks', () => {
   });
 
   after(async () => {
-    process.env.DO_NOT_BLOCK_GLOBAL_ROUTE = undefined;
     await testFixtureProvider.tearDown();
+    delete process.env.DO_NOT_BLOCK_GLOBAL_ROUTE;
   });
 
   it(`Should block global route '/', when DO_NOT_BLOCK_GLOBAL_ROUTE is set to true`, async () => {


### PR DESCRIPTION
## Changes

1. Implement `DO_NOT_BLOCK_GLOBAL_ROUTE` environment variable, which will cause the router to not use the `/` and `/security/authority` routes
2. Implement `/process_engine` route as an alternative to `/`
3. Implement `/process_engine/security/authority` as an alternative to `/security/authority`
4. Add tests for each new UseCase

## Issues

Closes #439

PR: #441

## How to test the changes

- Startup the ProcessEngine, without providing the `DO_NOT_BLOCK_GLOBAL_ROUTE` environment variable
- The routes `/`, `/process_engine`, `/security/authority`, `process_engine/security/authority` should all be working
- Now restart the ProcessEngine and supply the `DO_NOT_BLOCK_GLOBAL_ROUTE` variable (value doesn't matter)
- Only the routes `/process_engine` and `process_engine/security/authority` should be working now