### PR TITLE
✨ Add flag for disabling Http endpoints

### DIFF
--- a/src/test_setup/fixture_providers/setup_ioc_container.ts
+++ b/src/test_setup/fixture_providers/setup_ioc_container.ts
@@ -21,8 +21,6 @@ export async function initializeBootstrapper(): Promise<InvocationContainer> {
 
 function loadIocModules(): Array<any> {
 
-  const httpIsEnabled = process.env.NO_HTTP === undefined;
-
   const iocModuleNames = [
     '@essential-projects/bootstrapper',
     '@essential-projects/bootstrapper_node',
@@ -41,6 +39,7 @@ function loadIocModules(): Array<any> {
     '@process-engine/persistence_api.repositories.sequelize',
     '@process-engine/persistence_api.services',
     '@process-engine/persistence_api.use_cases',
+    '.',
   ];
 
   const httpIocModules = [
@@ -49,6 +48,7 @@ function loadIocModules(): Array<any> {
     '@process-engine/management_api_http',
   ];
 
+  const httpIsEnabled = process.env.NO_HTTP === undefined;
   if (httpIsEnabled) {
     iocModuleNames.push(...httpIocModules);
   }

--- a/src/test_setup/fixture_providers/setup_ioc_container.ts
+++ b/src/test_setup/fixture_providers/setup_ioc_container.ts
@@ -1,34 +1,5 @@
 import {InvocationContainer} from 'addict-ioc';
 
-const iocModuleNames: Array<string> = [
-  '@essential-projects/bootstrapper',
-  '@essential-projects/bootstrapper_node',
-  '@essential-projects/event_aggregator',
-  '@essential-projects/http',
-  '@essential-projects/http_extension',
-  '@essential-projects/sequelize_connection_manager',
-  '@essential-projects/timing',
-  '@process-engine/consumer_api_core',
-  '@process-engine/consumer_api_http',
-  '@process-engine/iam',
-  '@process-engine/logging_api_core',
-  '@process-engine/logging.repository.file_system',
-  '@process-engine/metrics_api_core',
-  '@process-engine/metrics.repository.file_system',
-  '@process-engine/management_api_core',
-  '@process-engine/management_api_http',
-  '@process-engine/process_engine_core',
-  '@process-engine/persistence_api.repositories.sequelize',
-  '@process-engine/persistence_api.services',
-  '@process-engine/persistence_api.use_cases',
-  '.',
-];
-
-const iocModules: Array<any> = iocModuleNames.map((moduleName: string): any => {
-  // eslint-disable-next-line
-  return require(`${moduleName}/ioc_module`);
-});
-
 export async function initializeBootstrapper(): Promise<InvocationContainer> {
 
   const container: InvocationContainer = new InvocationContainer({
@@ -37,6 +8,8 @@ export async function initializeBootstrapper(): Promise<InvocationContainer> {
     },
   });
 
+  const iocModules = loadIocModules();
+
   for (const iocModule of iocModules) {
     iocModule.registerInContainer(container);
   }
@@ -44,4 +17,46 @@ export async function initializeBootstrapper(): Promise<InvocationContainer> {
   container.validateDependencies();
 
   return container;
+}
+
+function loadIocModules(): Array<any> {
+
+  const httpIsEnabled = process.env.NO_HTTP === undefined;
+
+  const iocModuleNames = [
+    '@essential-projects/bootstrapper',
+    '@essential-projects/bootstrapper_node',
+    '@essential-projects/event_aggregator',
+    '@essential-projects/http',
+    '@essential-projects/sequelize_connection_manager',
+    '@essential-projects/timing',
+    '@process-engine/consumer_api_core',
+    '@process-engine/iam',
+    '@process-engine/logging_api_core',
+    '@process-engine/logging.repository.file_system',
+    '@process-engine/metrics_api_core',
+    '@process-engine/metrics.repository.file_system',
+    '@process-engine/management_api_core',
+    '@process-engine/process_engine_core',
+    '@process-engine/persistence_api.repositories.sequelize',
+    '@process-engine/persistence_api.services',
+    '@process-engine/persistence_api.use_cases',
+  ];
+
+  const httpIocModules = [
+    '@essential-projects/http_extension',
+    '@process-engine/consumer_api_http',
+    '@process-engine/management_api_http',
+  ];
+
+  if (httpIsEnabled) {
+    iocModuleNames.push(...httpIocModules);
+  }
+
+  const iocModules = iocModuleNames.map((moduleName: string): any => {
+    // eslint-disable-next-line
+    return require(`${moduleName}/ioc_module`);
+  });
+
+  return iocModules;
 }

--- a/src/test_setup/fixture_providers/test_fixture_provider.ts
+++ b/src/test_setup/fixture_providers/test_fixture_provider.ts
@@ -70,7 +70,11 @@ export class TestFixtureProvider {
     await this.runMigrations();
     await this.initializeBootstrapper();
     await this.bootstrapper.start();
-    await configureGlobalRoutes(this.container);
+
+    const httpIsEnabled = process.env.NO_HTTP === undefined;
+    if (httpIsEnabled) {
+      await configureGlobalRoutes(this.container);
+    }
 
     await this.createMockIdentities();
 

--- a/test/0_global_routes/no_http_flag.js
+++ b/test/0_global_routes/no_http_flag.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const should = require('should');
+const TestFixtureProvider = require('../../dist/commonjs/test_setup').TestFixtureProvider;
+
+const HttpClient = require('@essential-projects/http').HttpClient;
+
+const consumerApiRestSettings = require('@process-engine/consumer_api_contracts').restSettings;
+const managementApiRestSettings = require('@process-engine/management_api_contracts').restSettings;
+
+describe('Disable HttpEndpoints - ', () => {
+
+  let httpClient;
+
+  let testFixtureProvider;
+
+  before(async () => {
+    process.env.NO_HTTP = true;
+    testFixtureProvider = new TestFixtureProvider();
+    await testFixtureProvider.initializeAndStart();
+
+    httpClient = new HttpClient();
+    httpClient.config = {
+      url: 'http://localhost:32413',
+    };
+  });
+
+  after(async () => {
+    await testFixtureProvider.tearDown();
+    delete process.env.NO_HTTP;
+  });
+
+  it(`Global route '/' should not be available`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    try {
+      const response = await httpClient.get('', requestHeaders);
+      should.fail(response, undefined, `The HTTP endpoint should be disabled!`);
+    } catch (error) {
+      should(error.code).be.equal('EUNAVAILABLE');
+    }
+  });
+
+  it(`Global route '/security/authority' should not be available`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    try {
+      const routeToCall = 'security/authority';
+      const response = await httpClient.get(routeToCall, requestHeaders);
+      should.fail(response, undefined, `The HTTP endpoint should be disabled!`);
+    } catch (error) {
+      should(error.code).be.equal('EUNAVAILABLE');
+    }
+  });
+
+  it(`The Consumer API routes should not be available`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    const routeNames = Object.keys(consumerApiRestSettings.paths);
+
+    for (let i = 0; i <= routeNames.length; i++) {
+      const route = `api/consumer/v1/${routeNames[i]}`;
+
+      const responseCode = await sendHttpRequest(route, requestHeaders);
+      should(responseCode).be.equal('EUNAVAILABLE', `HTTP endpoints are disabled, but the route "${route}" was still accessible!`);
+    }
+  });
+
+  it(`The Management API routes should not be available`, async () => {
+
+    const requestHeaders = {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: testFixtureProvider.identities.defaultUser,
+      },
+    };
+
+    const routeNames = Object.keys(managementApiRestSettings.paths);
+
+    for (let i = 0; i <= routeNames.length; i++) {
+      const route = `api/management/v1/${routeNames[i]}`;
+
+      const responseCode = await sendHttpRequest(route, requestHeaders);
+      should(responseCode).be.equal('EUNAVAILABLE', `HTTP endpoints are disabled, but the route "${route}" was still accessible!`);
+    }
+  });
+
+  async function sendHttpRequest(route, requestHeaders) {
+
+    try {
+      const response = await httpClient.get(route, requestHeaders);
+      return response.status;
+    } catch (error) {
+      return error.code;
+    }
+  }
+});


### PR DESCRIPTION
## Changes

1. Implement `NO_HTTP` environment variable
    - When set, this flag will prevent the HttpExtension and the HttpEndpoints for ConsumerAPI and ManagementAPI to be initialized during startup
4. Add tests for the new flag

## Issues

Closes #438

PR: #442

## How to test the changes

- Startup the ProcessEngine, without providing the `NO_HTTP` environment variable
- All http endpoints should be available
- Now restart the ProcessEngine and supply the `NO_HTTP` variable (value doesn't matter)
- The process engine should ne accessible through http