### PR TITLE
♻️ Change cwd to the ProcessEngine's cwd, before running post-migrations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -160,7 +160,16 @@ async function runPostMigrations(): Promise<void> {
   try {
     logger.info('Running post-migration scripts.');
 
+    // NOTE:
+    // When embedding the ProcessEngine, the cwd may not necessarily be the directory that contains the runtimes.
+    // However, to access npm scripts, the cwd must be that directory.
+    // To get around this issue, we temporarily change the cwd to the ProcessEngine's location, run the post-migrations
+    // and restore the old cwd afterwards.
+    const currentWorkingDir = process.cwd();
+    const runtimeDir = path.resolve(__dirname, '..', '..');
+    process.chdir(runtimeDir);
     await execAsync('npm run postMigrations');
+    process.chdir(currentWorkingDir);
 
     logger.info('Post-Migrations successfully executed.');
   } catch (error) {


### PR DESCRIPTION
## Changes

Before running the post-migrations, the processes' `cwd` is changes to the directory the runtime is in. 

This is necessary, when embedding the runtime in another application, where the `cwd` may not necessarily be the same as the directory the ProcessEngine is located at.

## Issues

PR: #448

## How to test the changes

Easiest way to test this would be to use this feature branch in BPMN Studio.
If the app starts up without a hitch, then everything is fine.