### PR TITLE
🔒 Prevent use of misconfigured events

### DIFF
--- a/bpmn/cyclic_timers_disabled.bpmn
+++ b/bpmn/cyclic_timers_disabled.bpmn
@@ -23,7 +23,7 @@
       </bpmn:extensionElements>
       <bpmn:outgoing>SequenceFlow_1jdocur</bpmn:outgoing>
       <bpmn:timerEventDefinition>
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression" />
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">* 1 * * * *</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0sklcf5" sourceRef="Task_1ka46jy" targetRef="EndEvent_0eie6q6" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -651,9 +651,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.12.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-alpha.8.tgz",
-      "integrity": "sha512-Va4ZChcg6D5+LDrOdGhUvOddFbssBxtbLMkuBD7vbN37qikJdAY8FGOAu0woo2GxuOfA59vDwYuqu0n+YmWE2w==",
+      "version": "12.12.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-alpha.9.tgz",
+      "integrity": "sha512-YT6Y/DJbhkQ8e8o01p9Pp/R/RVuWi8pP4dhl3/zm9yo8iQ/glzhwVm7uFpu6cUOi8OcFCG1fXWGGQ4CAKbzL3g==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -651,9 +651,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.12.0-feature-ba0f17-k1qewnej",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-feature-ba0f17-k1qewnej.tgz",
-      "integrity": "sha512-jjQnhuYPVN76if6VTKo93X6aBS8vOrss4WZrwqlJBYssvzDPF/vLcaKP2/2INE7363Lf+V1jYiKzvmbtUoEe0g==",
+      "version": "12.12.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-alpha.8.tgz",
+      "integrity": "sha512-Va4ZChcg6D5+LDrOdGhUvOddFbssBxtbLMkuBD7vbN37qikJdAY8FGOAu0woo2GxuOfA59vDwYuqu0n+YmWE2w==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -651,9 +651,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.12.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-alpha.7.tgz",
-      "integrity": "sha512-VdpuyXoeIi3GnQPuJdZAJjXpkUX5urZNVk/wrBmL/yrHO3u+Z9TS0YdukUAQrXODPeIH9MB0zD51wKUXrmsxXw==",
+      "version": "12.12.0-feature-ba0f17-k1qewnej",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.12.0-feature-ba0f17-k1qewnej.tgz",
+      "integrity": "sha512-jjQnhuYPVN76if6VTKo93X6aBS8vOrss4WZrwqlJBYssvzDPF/vLcaKP2/2INE7363Lf+V1jYiKzvmbtUoEe0g==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
@@ -980,9 +980,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "addict-ioc": {
@@ -1746,9 +1746,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
+      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@process-engine/management_api_http": "5.1.0",
     "@process-engine/metrics_api_core": "2.0.0",
     "@process-engine/metrics.repository.file_system": "2.0.0",
-    "@process-engine/process_engine_core": "12.12.0-alpha.8",
+    "@process-engine/process_engine_core": "12.12.0-alpha.9",
     "@process-engine/persistence_api.repositories.sequelize": "1.1.0-alpha.3",
     "@process-engine/persistence_api.services": "1.1.0-alpha.3",
     "@process-engine/persistence_api.use_cases": "1.1.0-alpha.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@process-engine/management_api_http": "5.1.0",
     "@process-engine/metrics_api_core": "2.0.0",
     "@process-engine/metrics.repository.file_system": "2.0.0",
-    "@process-engine/process_engine_core": "12.12.0-alpha.7",
+    "@process-engine/process_engine_core": "feature~prevent_use_of_misconfigured_timer_events",
     "@process-engine/persistence_api.repositories.sequelize": "1.1.0-alpha.3",
     "@process-engine/persistence_api.services": "1.1.0-alpha.3",
     "@process-engine/persistence_api.use_cases": "1.1.0-alpha.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@process-engine/management_api_http": "5.1.0",
     "@process-engine/metrics_api_core": "2.0.0",
     "@process-engine/metrics.repository.file_system": "2.0.0",
-    "@process-engine/process_engine_core": "feature~prevent_use_of_misconfigured_timer_events",
+    "@process-engine/process_engine_core": "12.12.0-alpha.8",
     "@process-engine/persistence_api.repositories.sequelize": "1.1.0-alpha.3",
     "@process-engine/persistence_api.services": "1.1.0-alpha.3",
     "@process-engine/persistence_api.use_cases": "1.1.0-alpha.3",


### PR DESCRIPTION
## Changes

Refactor EventParser
1. Only allow one EventDefinition for each event
2. Add sanity checks for MessageEvents, SignalEvents and TimerEvents
3. Full Changelog: https://github.com/process-engine/process_engine_core/pull/303


## Issues
 
Closes #437

PR: #303

## How to test the changes

- Try deploying ProcessModels with MessageEvents or SignalEvents that are missing references to a message or signal
- Try deploying ProcessModels with TimerEvents that are missing a timer type or value

Each of these cases should fail. Everything else should work.