### PR TITLE
 ✨ Enhance embedding support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,6 +103,12 @@ function parseArguments(args: startupArgs | string): void {
     logger.verbose(`Minimal Setup: ${args.minimalSetup}`);
     minimalSetup = args.minimalSetup;
   }
+
+  if (typeof args === 'object' && args.logFilePath !== undefined) {
+    logger.verbose(`Using log file path: ${args.logFilePath}`);
+    process.env.process_engine__logging_repository__output_path = path.resolve(args.logFilePath, 'logs');
+    process.env.process_engine__metrics_repository__output_path = path.resolve(args.logFilePath, 'metrics');
+  }
 }
 
 function setWorkingDirectory(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,7 @@ function parseArguments(args: startupArgs | string): void {
     ? args.sqlitePath
     : args as string;
 
-  container = typeof args === 'object' && args.container !== undefined
+  container = typeof args === 'object' && args.container instanceof InvocationContainer
     ? args.container
     : new InvocationContainer(containerSettings);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,9 +27,9 @@ let sqlitePath: string;
 let minimalSetup = false;
 
 type startupArgs = {
-  sqlitePath?: string,
-  container?: InvocationContainer,
-  minimalSetup?: boolean
+  sqlitePath?: string;
+  container?: InvocationContainer;
+  minimalSetup?: boolean;
 }
 
 const httpIsEnabled = process.env.NO_HTTP === undefined;
@@ -37,6 +37,7 @@ const httpIsEnabled = process.env.NO_HTTP === undefined;
 // The folder location for the skeleton-electron app was a different one,
 // than the one we are using now. The BPMN Studio needs to be able to provide
 // a path to the databases, so that the backend can access them.
+// eslint-disable-next-line consistent-return
 export async function startRuntime(args: startupArgs | string): Promise<void> {
 
   parseArguments(args);
@@ -54,7 +55,7 @@ export async function startRuntime(args: startupArgs | string): Promise<void> {
     environment.setDatabasePaths(sqlitePath);
   }
 
-  await runMigrations(sqlitePath);
+  await runMigrations();
   await runPostMigrations();
 
   setWorkingDirectory();
@@ -87,8 +88,8 @@ function parseArguments(args: startupArgs | string): void {
     : new InvocationContainer(containerSettings);
 
   minimalSetup = typeof args === 'object'
-  ? args.minimalSetup
-  : false;
+    ? args.minimalSetup
+    : false;
 
 }
 
@@ -175,7 +176,7 @@ function validateEnvironment(): void {
   process.exit(1);
 }
 
-async function runMigrations(sqlitePath: string): Promise<void> {
+async function runMigrations(): Promise<void> {
 
   const repositories = [
     'correlation',

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,11 @@ export async function startRuntime(args: startupArgs | string): Promise<void> {
 
   parseArguments(args);
 
+  if (minimalSetup === true) {
+    logger.warn('MinimalSetup is set to true. Will only load the ioc modules into the container. EVERYTHING else is up to you!');
+    return loadIocModules();
+  }
+
   setConfigPath();
   validateEnvironment();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ let container: InvocationContainer;
 let sqlitePath: string;
 let minimalSetup = false;
 
+// Allows an embedding application like BPMN Studio to pass its own settings to the runtime.
 type startupArgs = {
   sqlitePath?: string;
   logFilePath?: string;
@@ -35,9 +36,6 @@ type startupArgs = {
 
 const httpIsEnabled = process.env.NO_HTTP === undefined;
 
-// The folder location for the skeleton-electron app was a different one,
-// than the one we are using now. The BPMN Studio needs to be able to provide
-// a path to the databases, so that the backend can access them.
 // eslint-disable-next-line consistent-return
 export async function startRuntime(args: startupArgs | string): Promise<void> {
 


### PR DESCRIPTION
## Changes

Enhance support for embedding the ProcessEngine into another application.

1. Allow for startup parameters to be passed as an object with the following parameters:
    -  `sqlitePath`: A custom path to where the ProcessEngine should store its SQLite databases
    - `logFilePath`: A custom path to where the ProcessEngine should write its logs and metrics
    - `container`: A container for registering IoC dependencies. If none is provided, the ProcessEngine will create its own container
    - `minimalSetup`: Indicates if only a minimal setup should be done (See 3. and 4.)
2. Alternatively, you can also provide only a string for `sqliteStoragePath` as argument. 
3. Seperate ioc module loading from bootstrapper initialization
4. When `minimalSetup` is provided, the ProcessEngine will only load its ioc modules into the container and then return.
    - This is meant to be used in conjunction with the `container` parameter. Providing it isn't mandatory, but why would you not do so?
    - Minimal setups are useful, if you are embedding the ProcessEngine into another application that runs its own environmental setup, its own migrations, etc.
    -  But keep in mind, if you use this option, then you really do have to handle the **entire** startup yourself!

## Issues

PR: #457

## How to test the changes

Fully parametrized:
- Start the runtime and provide an object with the parameters described above
- See that the ProcessEngine will place its ioc registrations into the provided container
- See that, when `minimalSetup` is set to `true`, the ProcessEngine will do nothing but load its dependencies into the container
- See that the sqlite path provided with `sqlitePath` is used

With string argument:
- Start the runtime and only provide a string with an sqliteStoragePath (this has been the current startup mode)
- See that the runtime will run a full setup with its own ioc container and use the sqlitePath you provided

Default startup:
- Start the runtime and don't provide any arguments
- See thatthe runtime runs a full setup and uses the sqliteStoragePath from its own configs