### PR TITLE
🐛Fix Postmigrations for flowNodeInstances

### DIFF
--- a/src/post-migrations/9.1.0-add_flow_node_instance_name_and_lane.ts
+++ b/src/post-migrations/9.1.0-add_flow_node_instance_name_and_lane.ts
@@ -192,7 +192,11 @@ function getLaneForFlowNodeInstance(flowNodeInstance, processModelFacade): Promi
 
 async function setLaneAndNameForFlowNodeInstance(flowNodeInstance, name, lane): Promise<any> {
   logger.info('Updating FlowNodeInstance properties');
-  const query = `UPDATE "FlowNodeInstances" SET "flowNodeName" = '${name}', "flowNodeLane" = '${lane}' WHERE "id" = ${flowNodeInstance.id}`;
+  const flowNodeName = name ? name.replace(/'/g, '\'\'') : name;
+  const flowNodeLane = name ? lane.replace(/'/g, '\'\'') : name;
+
+  const query = `UPDATE "FlowNodeInstances" SET "flowNodeName" = '${flowNodeName}',
+   "flowNodeLane" = '${flowNodeLane}' WHERE "id" = ${flowNodeInstance.id}`;
 
   await flowNodeInstanceDbQueryInterface.sequelize.query(query);
 }

--- a/src/post-migrations/9.1.0-add_flow_node_instance_name_and_lane.ts
+++ b/src/post-migrations/9.1.0-add_flow_node_instance_name_and_lane.ts
@@ -193,7 +193,7 @@ function getLaneForFlowNodeInstance(flowNodeInstance, processModelFacade): Promi
 async function setLaneAndNameForFlowNodeInstance(flowNodeInstance, name, lane): Promise<any> {
   logger.info('Updating FlowNodeInstance properties');
   const flowNodeName = name ? name.replace(/'/g, '\'\'') : name;
-  const flowNodeLane = name ? lane.replace(/'/g, '\'\'') : name;
+  const flowNodeLane = lane ? lane.replace(/'/g, '\'\'') : lane;
 
   const query = `UPDATE "FlowNodeInstances" SET "flowNodeName" = '${flowNodeName}',
    "flowNodeLane" = '${flowNodeLane}' WHERE "id" = ${flowNodeInstance.id}`;


### PR DESCRIPTION
## Changes

1. Fix bug where single quotes need to be escaped in SQL query

PR: #462

## How to test the changes

Set the name of a flowNode to `dfkfs('dd')` and see that the migrations are successful
