### PR TITLE
🔊 Print identity and requested claim when a claim check fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,9 +81,9 @@
       }
     },
     "@essential-projects/errors_ts": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.5.3.tgz",
-      "integrity": "sha512-9TIlwKFmGq85b2RAM22ETkgj2wBaM/FaT4u3UHhasuzXd2NWEgPoejQtaytJQxhxY/9Ac3n2PGcRjTa6zbpeYQ=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@essential-projects/errors_ts/-/errors_ts-1.6.1.tgz",
+      "integrity": "sha512-K1HTDSXqYfMOO0e0mVz5jCVPk520fJaGoofrAavVg5U2tQTDqpEMwyhGXrts+NrbMbJUPHkR/VQCjGdqT6dELg=="
     },
     "@essential-projects/eslint-config": {
       "version": "1.1.4",
@@ -418,9 +418,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.2.tgz",
-      "integrity": "sha512-fK7j1rbm0uKD+3HRRqO9xe59HeVgOu/n5cLS+uPqXANswdi0q3TtZREexESRo2FmSvzSohFuYnynS0JaQmXRmA==",
+      "version": "1.7.3-feature-aa0363-k3em38g4",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.3-feature-aa0363-k3em38g4.tgz",
+      "integrity": "sha512-TSt0WKyo4kHI6tNUo3Dbrm2xOuLZj4Je+7gBZGQfePLIkVtqvRLporMMs81BJT51OJOA12ORuJZCsdIhL2LlVw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",
@@ -517,6 +517,13 @@
         "express": "^4.17.0",
         "openapi-doc": "4.1.6",
         "socket.io": "^2.2.0"
+      },
+      "dependencies": {
+        "openapi-doc": {
+          "version": "4.1.6",
+          "resolved": "https://registry.npmjs.org/openapi-doc/-/openapi-doc-4.1.6.tgz",
+          "integrity": "sha512-Gg2dAqpjHX5u3lg+Wja0kVo4JV34GoEk3iPrVyeA0VIqDwre3bl4Q73fV6//oiTNoq9MUvsDYQRSQhcr1Rz2pA=="
+        }
       }
     },
     "@process-engine/persistence_api.contracts": {
@@ -734,9 +741,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-      "integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ=="
+      "version": "12.12.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
+      "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -744,9 +751,9 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
     "@types/sequelize": {
-      "version": "4.28.7",
-      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.28.7.tgz",
-      "integrity": "sha512-SN5v30XilB554wMpvPNuCbybKJk/0sraBOIDzh+PHfUhMlQgKwBbYjafLtOuH4HoDwq0a0ZlaS/JdVVH8ZWJ5Q==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/@types/sequelize/-/sequelize-4.28.8.tgz",
+      "integrity": "sha512-3n/iSpOtO5NynSBgEJ+738DK/ctxkqnVMvdPLZxrbZrf/rQgNm8wgDPDSarS1rmluvOe5ZMRDF8DXhts5MIbag==",
       "dev": true,
       "requires": {
         "@types/bluebird": "*",
@@ -806,12 +813,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.8.0.tgz",
-      "integrity": "sha512-ohqul5s6XEB0AzPWZCuJF5Fd6qC0b4+l5BGEnrlpmvXxvyymb8yw8Bs4YMF8usNAeuCJK87eFIHy8g8GFvOtGA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.9.0.tgz",
+      "integrity": "sha512-98rfOt3NYn5Gr9wekTB8TexxN6oM8ZRvYuphPs1Atfsy419SDLYCaE30aJkRiiTCwGEY98vOhFsEVm7Zs4toQQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.8.0",
+        "@typescript-eslint/experimental-utils": "2.9.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -819,32 +826,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.8.0.tgz",
-      "integrity": "sha512-jZ05E4SxCbbXseQGXOKf3ESKcsGxT8Ucpkp1jiVp55MGhOvZB2twmWKf894PAuVQTCgbPbJz9ZbRDqtUWzP8xA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.9.0.tgz",
+      "integrity": "sha512-0lOLFdpdJsCMqMSZT7l7W2ta0+GX8A3iefG3FovJjrX+QR8y6htFlFdU7aOVPL6pDvt6XcsOb8fxk5sq+girTw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.8.0",
+        "@typescript-eslint/typescript-estree": "2.9.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.8.0.tgz",
-      "integrity": "sha512-NseXWzhkucq+JM2HgqAAoKEzGQMb5LuTRjFPLQzGIdLthXMNUfuiskbl7QSykvWW6mvzCtYbw1fYWGa2EIaekw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.9.0.tgz",
+      "integrity": "sha512-fJ+dNs3CCvEsJK2/Vg5c2ZjuQ860ySOAsodDPwBaVlrGvRN+iCNC8kUfLFL8cT49W4GSiLPa/bHiMjYXA7EhKQ==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.8.0",
-        "@typescript-eslint/typescript-estree": "2.8.0",
+        "@typescript-eslint/experimental-utils": "2.9.0",
+        "@typescript-eslint/typescript-estree": "2.9.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.8.0.tgz",
-      "integrity": "sha512-ksvjBDTdbAQ04cR5JyFSDX113k66FxH1tAXmi+dj6hufsl/G0eMc/f1GgLjEVPkYClDbRKv+rnBFuE5EusomUw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.9.0.tgz",
+      "integrity": "sha512-v6btSPXEWCP594eZbM+JCXuFoXWXyF/z8kaSBSdCb83DF+Y7+xItW29SsKtSULgLemqJBT+LpT+0ZqdfH7QVmA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -2080,17 +2087,17 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
-      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
+      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.0",
+        "has-symbols": "^1.0.1",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-inspect": "^1.6.0",
+        "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "string.prototype.trimleft": "^2.1.0",
         "string.prototype.trimright": "^2.1.0"
@@ -2153,9 +2160,9 @@
       }
     },
     "eslint": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
-      "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.7.1.tgz",
+      "integrity": "sha512-UWzBS79pNcsDSxgxbdjkmzn/B6BhsXMfUaOHnNwyE8nD+Q6pyT96ow2MccVayUTV4yMid4qLhMiQaywctRkBLA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2173,7 +2180,7 @@
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^11.7.0",
+        "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2186,7 +2193,7 @@
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
+        "optionator": "^0.8.3",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^6.1.2",
@@ -2442,6 +2449,12 @@
           "requires": {
             "escape-string-regexp": "^1.0.5"
           }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
         },
         "inquirer": {
           "version": "6.5.2",
@@ -3411,10 +3424,13 @@
       "dev": true
     },
     "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+      "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
     },
     "globby": {
       "version": "9.2.0",
@@ -4079,11 +4095,11 @@
       "dev": true
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -5335,9 +5351,9 @@
       }
     },
     "openapi-doc": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/openapi-doc/-/openapi-doc-4.1.6.tgz",
-      "integrity": "sha512-Gg2dAqpjHX5u3lg+Wja0kVo4JV34GoEk3iPrVyeA0VIqDwre3bl4Q73fV6//oiTNoq9MUvsDYQRSQhcr1Rz2pA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/openapi-doc/-/openapi-doc-4.2.0.tgz",
+      "integrity": "sha512-EuyYdPGyUuFtvFnTTkBvSsdZaYiLavaDMt2SwL7UDo0wW7aC4Mpoj5pKQrT+szwjXPKRHrAiULPZ68opKSJWAw=="
     },
     "optimist": {
       "version": "0.6.1",
@@ -5509,9 +5525,9 @@
       "dev": true
     },
     "path-key": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-      "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -6004,9 +6020,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.0.tgz",
+      "integrity": "sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -6503,9 +6519,9 @@
       }
     },
     "socket.io-adapter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+      "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
     },
     "socket.io-client": {
       "version": "2.3.0",
@@ -7071,9 +7087,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.0.tgz",
+      "integrity": "sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==",
       "optional": true,
       "requires": {
         "commander": "~2.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -418,9 +418,9 @@
       }
     },
     "@process-engine/iam": {
-      "version": "1.7.3-feature-aa0363-k3em38g4",
-      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.3-feature-aa0363-k3em38g4.tgz",
-      "integrity": "sha512-TSt0WKyo4kHI6tNUo3Dbrm2xOuLZj4Je+7gBZGQfePLIkVtqvRLporMMs81BJT51OJOA12ORuJZCsdIhL2LlVw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@process-engine/iam/-/iam-1.7.3.tgz",
+      "integrity": "sha512-Q0EUIv4AaDNDtN88t1n7lAMpuhIj+qrZslU7yA5Tb6AvTBNV84yJsVXzvZ5FEkXBJqfYDzCnhOJ2WU0V/+bvGQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.4.0",
         "@essential-projects/http_contracts": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@essential-projects/timing": "5.0.2",
     "@process-engine/consumer_api_core": "6.2.0",
     "@process-engine/consumer_api_http": "5.2.0",
-    "@process-engine/iam": "feature~increase_log_verbosity",
+    "@process-engine/iam": "1.7.3",
     "@process-engine/logging_api_core": "2.0.0",
     "@process-engine/logging.repository.file_system": "2.0.0",
     "@process-engine/management_api_core": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@essential-projects/timing": "5.0.2",
     "@process-engine/consumer_api_core": "6.2.0",
     "@process-engine/consumer_api_http": "5.2.0",
-    "@process-engine/iam": "1.7.2",
+    "@process-engine/iam": "feature~increase_log_verbosity",
     "@process-engine/logging_api_core": "2.0.0",
     "@process-engine/logging.repository.file_system": "2.0.0",
     "@process-engine/management_api_core": "6.2.0",


### PR DESCRIPTION
## Changes

When a claim check runs into a 403 error, the runtime will now print out the identity and the claim that was requested.

## Issues

Closes #475 

PR: #476

## How to test the changes

- Run a few requests you are sure will produce a 403
- Note that the logged error will display the identity used, as well as the claim that was requested