### PR TITLE
🐛 Hotfix: Fix crash during environment setup when using non-sqlite environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Standalone application that provides access to the .TS implementation of the ProcessEngine.",
   "bin": {
     "process-engine": "./bin/index.js"

--- a/src/modules/environment.ts
+++ b/src/modules/environment.ts
@@ -6,26 +6,34 @@ import * as Sequelize from 'sequelize';
 
 export function setDatabasePaths(sqlitePath: string): void {
 
-  const correlationRepositoryConfig = readConfigFile('sqlite', 'correlation_repository.json');
-  const externalTaskRepositoryConfig = readConfigFile('sqlite', 'external_task_repository.json');
-  const flowNodeInstanceRepositoryConfig = readConfigFile('sqlite', 'flow_node_instance_repository.json');
-  const processModelRepositoryConfig = readConfigFile('sqlite', 'process_model_repository.json');
-
   const databaseBasePath = getSqliteStoragePath(sqlitePath);
 
-  const correlationRepositoryStoragePath = path.join(databaseBasePath, correlationRepositoryConfig.storage);
-  const externalTaskRepositoryStoragePath = path.join(databaseBasePath, externalTaskRepositoryConfig.storage);
-  const flowNodeRepositoryStoragePath = path.join(databaseBasePath, flowNodeInstanceRepositoryConfig.storage);
-  const processModelRepositoryStoragePath = path.join(databaseBasePath, processModelRepositoryConfig.storage);
-
   const logsStoragePath = path.join(databaseBasePath, 'logs');
-
-  process.env.process_engine__correlation_repository__storage = correlationRepositoryStoragePath;
-  process.env.process_engine__external_task_repository__storage = externalTaskRepositoryStoragePath;
-  process.env.process_engine__process_model_repository__storage = processModelRepositoryStoragePath;
-  process.env.process_engine__flow_node_instance_repository__storage = flowNodeRepositoryStoragePath;
-
   process.env.process_engine__logging_repository__log_output_path = logsStoragePath;
+
+  const correlationRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'correlation_repository.json');
+  if (correlationRepositoryConfig.storage) {
+    const correlationRepositoryStoragePath = path.join(databaseBasePath, correlationRepositoryConfig.storage);
+    process.env.process_engine__correlation_repository__storage = correlationRepositoryStoragePath;
+  }
+
+  const externalTaskRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'external_task_repository.json');
+  if (externalTaskRepositoryConfig.storage) {
+    const externalTaskRepositoryStoragePath = path.join(databaseBasePath, externalTaskRepositoryConfig.storage);
+    process.env.process_engine__external_task_repository__storage = externalTaskRepositoryStoragePath;
+  }
+
+  const flowNodeInstanceRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'flow_node_instance_repository.json');
+  if (flowNodeInstanceRepositoryConfig.storage) {
+    const flowNodeRepositoryStoragePath = path.join(databaseBasePath, flowNodeInstanceRepositoryConfig.storage);
+    process.env.process_engine__flow_node_instance_repository__storage = flowNodeRepositoryStoragePath;
+  }
+
+  const processModelRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'process_model_repository.json');
+  if (processModelRepositoryConfig.storage) {
+    const processModelRepositoryStoragePath = path.join(databaseBasePath, processModelRepositoryConfig.storage);
+    process.env.process_engine__process_model_repository__storage = processModelRepositoryStoragePath;
+  }
 }
 
 export function getSqliteStoragePath(sqlitePath?: string): string {


### PR DESCRIPTION
## Changes

This fixes reference issues when setting up the Runtime with a DB environment other than SQLite.

## Issues

PR: #483

## How to test the changes

- Start the Runtime with any environment that does not use SQLite
- See that it works