### PR TITLE
🐛Fix publishing npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "assets": [
       "config/**/",
       "sequelize/**/",
-      "node_modules/**/"
+      "node_modules/**/",
+      "swagger.html"
     ],
     "scripts": [
       "node_modules/**/ioc_module.js"

--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
   "bugs": {
     "url": "https://github.com/process-engine/procese_engine_runtime/issues"
   },
-  "publishConfig": {
-    "registry": "https://www.npmjs.com"
-  },
   "pkg": {
     "assets": [
       "config/**/",


### PR DESCRIPTION
## Changes

1. Fix the 404 npm publish error. 
2. Fix 404 swagger.html when using windows installer

## Issues

PR: #485 

## How to test the changes

> Describe how others can test your changes (not required when fixing typos, linter errors and such)
