### PR TITLE
🐛 Fix Github Actions Workflow Conditions

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -202,7 +202,7 @@ jobs:
     name: "Create Tarball from Linux Sources"
     needs: prepare_version
     runs-on: ubuntu-18.04
-    if: contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'beta')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
 
     steps:
     - uses: actions/checkout@v1
@@ -235,7 +235,7 @@ jobs:
     name: "Create Tarball from macOS Sources"
     needs: prepare_version
     runs-on: macOS-latest
-    if: contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'beta')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
 
     steps:
     - uses: actions/checkout@v1
@@ -268,7 +268,7 @@ jobs:
     name: "Create Windows Sources"
     needs: prepare_version
     runs-on: windows-latest
-    if: contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'beta')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
 
     steps:
     - uses: actions/checkout@v1
@@ -299,7 +299,7 @@ jobs:
     name: "Create Zip File from Windows Sources"
     needs: create_windows_sources
     runs-on: macos-latest
-    if: contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'beta')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
 
     steps:
     - uses: actions/checkout@v1
@@ -323,7 +323,7 @@ jobs:
     name: "Build Windows Installer"
     needs: create_windows_sources
     runs-on: windows-latest
-    if: contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'beta')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
 
     steps:
     - uses: actions/checkout@v1
@@ -434,7 +434,7 @@ jobs:
     name: "Publish GitHub Release"
     needs: commit_and_tag_version
     runs-on: ubuntu-18.04
-    if: contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'beta')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
 
     steps:
     - uses: actions/checkout@v1
@@ -507,7 +507,7 @@ jobs:
     name: "Build & Publish Docker Image"
     needs: commit_and_tag_version
     runs-on: ubuntu-18.04
-    if: contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'beta')
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/develop'
     steps:
     - uses: actions/checkout@v1
 


### PR DESCRIPTION
> This prevents GitHub Actions from publishing branches that only contain the word `master`, `develop` or `beta`, like `feature/develop_feature_xy` or `release/v9.3.0-beta.1`

## Changes

1.  Fix Github Actions Workflow Conditions

PR: #490
