### PR TITLE
🔥Remove error boundary event name matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -582,9 +582,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.15.0-feature-263abc-k5m9ai64",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-263abc-k5m9ai64.tgz",
-      "integrity": "sha512-rYNr5lWuVywHjFCT1QtREKM1INmXl+s4crbvogX2mmubfQ7zLZsEDc/dbJ3o6tRiqdK/y1XtlkHrKJpfEIvjpg==",
+      "version": "12.15.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-alpha.1.tgz",
+      "integrity": "sha512-1qgbtOF3BV68UgfsFGLXUBWPzhU6y7nRRWv9zNIDotZMqKm4aleBN+f6/KR36cVj6WElFTY8ON1JGpQvOytxvw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.4.0-alpha.1",
+  "version": "9.4.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -582,9 +582,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.14.0.tgz",
-      "integrity": "sha512-B0O5gIwLO3u8ZcSfL0Cjyq9QPRGOqLIbnol3Up7HzavrQ00nbuLEySHiIh5ftQ8OiNhHG9GbhPs+DM0d0SCCkw==",
+      "version": "12.15.0-feature-263abc-k5m9ai64",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-263abc-k5m9ai64.tgz",
+      "integrity": "sha512-rYNr5lWuVywHjFCT1QtREKM1INmXl+s4crbvogX2mmubfQ7zLZsEDc/dbJ3o6tRiqdK/y1XtlkHrKJpfEIvjpg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
@@ -630,9 +630,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-          "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+          "version": "13.1.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+          "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
         }
       }
     },
@@ -665,9 +665,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-          "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+          "version": "13.1.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+          "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
         }
       }
     },
@@ -680,9 +680,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-          "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+          "version": "13.1.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+          "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
         }
       }
     },
@@ -727,9 +727,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-          "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+          "version": "13.1.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+          "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
         }
       }
     },
@@ -742,9 +742,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-          "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+          "version": "13.1.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+          "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
         }
       }
     },
@@ -798,9 +798,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
-      "integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
+      "version": "12.12.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
+      "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
       "dev": true
     },
     "@types/range-parser": {
@@ -838,9 +838,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-          "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+          "version": "13.1.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+          "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
         }
       }
     },
@@ -1029,11 +1029,11 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -1931,9 +1931,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.2.tgz",
-      "integrity": "sha512-YoKuru3Lyoy7yVTBSH2j7UxTqe/je3dWAruC0sHvZX1GNd5zX8SSLvQqEgO9b3Ex8IW+goFI9arEEsFIbulhOw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.3.tgz",
+      "integrity": "sha512-AwiVPKf3sKGMoWtFw0J7Y4MTZ4Iek67k4COWOwHqS8B9TOZ71DCfcoBmdamy8Y6mj4MDz0+VNUpC2HKHFHA3pg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -1986,24 +1986,16 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz",
-      "integrity": "sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
+      "integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        }
       }
     },
     "eslint": {
@@ -2455,9 +2447,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-glob": {
       "version": "3.1.1",
@@ -4096,9 +4088,9 @@
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
-          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.1.tgz",
+          "integrity": "sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -6202,9 +6194,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.1.7",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-          "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg=="
+          "version": "13.1.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+          "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.3.0",
     "@process-engine/persistence_api.services": "1.3.0",
     "@process-engine/persistence_api.use_cases": "1.3.0",
-    "@process-engine/process_engine_core": "feature~remove_error_boundary_event_name_matching",
+    "@process-engine/process_engine_core": "12.15.0-alpha.1",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.3.0",
     "@process-engine/persistence_api.services": "1.3.0",
     "@process-engine/persistence_api.use_cases": "1.3.0",
-    "@process-engine/process_engine_core": "12.14.0",
+    "@process-engine/process_engine_core": "feature~remove_error_boundary_event_name_matching",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.3",


### PR DESCRIPTION
## Changes

The `ErrorBoundaryEventHandler` no longer matches the name of a given error against the error attached to the BoundaryEvent.
This means that an error now only has to have a matching code and a message.

Closes #497

PR: #498

## How to test the changes

- Use an `ErrorBoundaryEvent` that uses a random value for the `name` property and attach it to any kind of activity (easiest would be a ScriptTask)
- Cause an error that uses a different name from the error on the `ErrorBoundaryEvent`
- See that the `ErrorBoundaryEvent` can handle the error