### PR TITLE
 💄 Improve log format

### DIFF
--- a/src/modules/environment.ts
+++ b/src/modules/environment.ts
@@ -23,27 +23,27 @@ export function setDatabasePaths(sqlitePath: string): void {
   const logsStoragePath = path.join(databaseBasePath, 'logs');
   process.env.process_engine__logging_repository__log_output_path = logsStoragePath;
 
-  const correlationRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'correlation_repository.json');
-  if (correlationRepositoryConfig.storage) {
-    const correlationRepositoryStoragePath = path.join(databaseBasePath, correlationRepositoryConfig.storage);
+  const correlationRepoConfig = readConfigFile<Sequelize.Options>(process.env.NODE_ENV, 'process_engine', 'correlation_repository.json');
+  if (correlationRepoConfig.storage) {
+    const correlationRepositoryStoragePath = path.join(databaseBasePath, correlationRepoConfig.storage);
     process.env.process_engine__correlation_repository__storage = correlationRepositoryStoragePath;
   }
 
-  const externalTaskRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'external_task_repository.json');
-  if (externalTaskRepositoryConfig.storage) {
-    const externalTaskRepositoryStoragePath = path.join(databaseBasePath, externalTaskRepositoryConfig.storage);
+  const externalTaskRepoConfig = readConfigFile<Sequelize.Options>(process.env.NODE_ENV, 'process_engine', 'external_task_repository.json');
+  if (externalTaskRepoConfig.storage) {
+    const externalTaskRepositoryStoragePath = path.join(databaseBasePath, externalTaskRepoConfig.storage);
     process.env.process_engine__external_task_repository__storage = externalTaskRepositoryStoragePath;
   }
 
-  const flowNodeInstanceRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'flow_node_instance_repository.json');
-  if (flowNodeInstanceRepositoryConfig.storage) {
-    const flowNodeRepositoryStoragePath = path.join(databaseBasePath, flowNodeInstanceRepositoryConfig.storage);
+  const flowNodeInstanceRepoConfig = readConfigFile<Sequelize.Options>(process.env.NODE_ENV, 'process_engine', 'flow_node_instance_repository.json');
+  if (flowNodeInstanceRepoConfig.storage) {
+    const flowNodeRepositoryStoragePath = path.join(databaseBasePath, flowNodeInstanceRepoConfig.storage);
     process.env.process_engine__flow_node_instance_repository__storage = flowNodeRepositoryStoragePath;
   }
 
-  const processModelRepositoryConfig = readConfigFile(process.env.NODE_ENV, 'process_model_repository.json');
-  if (processModelRepositoryConfig.storage) {
-    const processModelRepositoryStoragePath = path.join(databaseBasePath, processModelRepositoryConfig.storage);
+  const processModelRepoConfig = readConfigFile<Sequelize.Options>(process.env.NODE_ENV, 'process_engine', 'process_model_repository.json');
+  if (processModelRepoConfig.storage) {
+    const processModelRepositoryStoragePath = path.join(databaseBasePath, processModelRepoConfig.storage);
     process.env.process_engine__process_model_repository__storage = processModelRepositoryStoragePath;
   }
 }
@@ -76,13 +76,13 @@ export function getUserConfigFolder(): string {
   }
 }
 
-export function readConfigFile(env: string, repositoryConfigFileName: string): Sequelize.Options {
+export function readConfigFile<TResult>(env: string, ...pathSegments: Array<string>): TResult {
 
-  const configFilePath = path.resolve(process.env.CONFIG_PATH, env, 'process_engine', repositoryConfigFileName);
+  const configFilePath = path.resolve(process.env.CONFIG_PATH, env, ...pathSegments);
 
   const fileContent = fs.readFileSync(configFilePath, 'utf-8');
 
-  const parsedFileContent = JSON.parse(fileContent) as Sequelize.Options;
+  const parsedFileContent = JSON.parse(fileContent) as TResult;
 
   return parsedFileContent;
 }

--- a/src/modules/migrator.ts
+++ b/src/modules/migrator.ts
@@ -26,7 +26,7 @@ export async function migrate(repositoryName: string, sqlitePath: string): Promi
 function getConfig(env: string, repositoryName: string, sqlitePath?: string): Sequelize.Options {
 
   const repositoryConfigFileName = `${repositoryName}_repository.json`;
-  const config = environment.readConfigFile(env, repositoryConfigFileName);
+  const config = environment.readConfigFile<Sequelize.Options>(env, 'process_engine', repositoryConfigFileName);
 
   if (config.dialect === 'sqlite') {
     const fullSqlitePath = environment.getSqliteStoragePath(sqlitePath);

--- a/src/post-migrations/9.1.0-add_flow_node_instance_name_and_lane.ts
+++ b/src/post-migrations/9.1.0-add_flow_node_instance_name_and_lane.ts
@@ -69,9 +69,9 @@ async function setup(sqlitePath?: string): Promise<void> {
 
   await parser.initialize();
 
-  const correlationRepoConfig = environment.readConfigFile(nodeEnv, 'correlation_repository.json');
-  const flowNodeInstanceRepoConfig = environment.readConfigFile(nodeEnv, 'flow_node_instance_repository.json');
-  const processModelRepoConfig = environment.readConfigFile(nodeEnv, 'correlation_repository.json');
+  const correlationRepoConfig = environment.readConfigFile<Sequelize.Options>(nodeEnv, 'process_engine', 'correlation_repository.json');
+  const flowNodeInstanceRepoConfig = environment.readConfigFile<Sequelize.Options>(nodeEnv, 'process_engine', 'flow_node_instance_repository.json');
+  const processModelRepoConfig = environment.readConfigFile<Sequelize.Options>(nodeEnv, 'process_engine', 'correlation_repository.json');
 
   nodeEnvIsPostgres = flowNodeInstanceRepoConfig.dialect === 'postgres';
 


### PR DESCRIPTION
## Changes

1. Allow to pass multiple path segments to `readConfigFile`
2. Add return type parameter to `readConfigFile`
3. Print address & port info at the top of the ProcessEngine logs
4. Get address & port info from the config files, instead of the HttpExtension
    - The HttpExtension is not available, until the Runtime has started up, so we cannot get the actual address from there, since the logs are supposed to be printed at startup
    - This will probably not be an issue yet, because if the port is taken, the Runtime will just shut down
    - If we make use of port discovery at some point, this issue needs to be revisited, because then the discovered port may not be the same as the one that was configured

## Issues

Closes #495

PR: #500 

## How to test the changes

Start the runtime and read the logs.

![Bildschirmfoto 2020-01-21 um 10 08 32](https://user-images.githubusercontent.com/15343316/72791118-11ef8880-3c37-11ea-8fb9-614d1292756a.png)