### PR TITLE
♻️ Default empty external ServiceTask results to `{}`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.4.0-alpha.4",
+  "version": "9.4.0-alpha.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -606,9 +606,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.15.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-beta.1.tgz",
-      "integrity": "sha512-gO5vySnQYyanyI9BBph2p9qZm27E11PjCF0qAfU3hoLSaYj3LnvWvhpNB4I3qSy8zSjMKFsf7NrLsV33Q0whUA==",
+      "version": "12.15.0-feature-bf9088-k5nw39vw",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-bf9088-k5nw39vw.tgz",
+      "integrity": "sha512-0fF/vLVcr8bWw2dbT7D/OC6Ntuoa5GGFQZT+kiSoanDe2g8LuXow1QEBVNElLFysgB0imoUKa6x3Og2JA7A0FA==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.4.0-alpha.5",
+  "version": "9.4.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -606,9 +606,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.15.0-feature-bf9088-k5nw39vw",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-bf9088-k5nw39vw.tgz",
-      "integrity": "sha512-0fF/vLVcr8bWw2dbT7D/OC6Ntuoa5GGFQZT+kiSoanDe2g8LuXow1QEBVNElLFysgB0imoUKa6x3Og2JA7A0FA==",
+      "version": "12.15.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-alpha.2.tgz",
+      "integrity": "sha512-IhbDi6NyDbGOvBTTAaYKoeyd2/lVROQTI7Rwao6C3bfj69Jvj7hZnZTeKqXASRQUuppLNkeSxwMyl99x2spoMw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
@@ -741,9 +741,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.1.tgz",
-      "integrity": "sha512-9e7jj549ZI+RxY21Cl0t8uBnWyb22HzILupyHZjYEVK//5TT/1bZodU+yUbLnPdoYViBBnNWbxp4zYjGV0zUGw==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
+      "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -1990,9 +1990,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.3.tgz",
-      "integrity": "sha512-AwiVPKf3sKGMoWtFw0J7Y4MTZ4Iek67k4COWOwHqS8B9TOZ71DCfcoBmdamy8Y6mj4MDz0+VNUpC2HKHFHA3pg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -5189,9 +5189,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-      "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+      "integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.3.0",
     "@process-engine/persistence_api.services": "1.3.0",
     "@process-engine/persistence_api.use_cases": "1.3.0",
-    "@process-engine/process_engine_core": "12.15.0-beta.1",
+    "@process-engine/process_engine_core": "feature~fix_external_task_payload_initialization",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.3.0",
     "@process-engine/persistence_api.services": "1.3.0",
     "@process-engine/persistence_api.use_cases": "1.3.0",
-    "@process-engine/process_engine_core": "feature~fix_external_task_payload_initialization",
+    "@process-engine/process_engine_core": "12.15.0-alpha.2",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.3",


### PR DESCRIPTION
## Changes

1. When an ExternalTask finishes with `{}`, `null` or `undefined`, the resulting `onExit` token of the corresponding ServiceTask will be `{}`. 
2. Fix reference error, when a message received from an ExternalTaskWorker is empty.

## Issues

Closes #502

PR: #504

## How to test the changes

- Run an external ServiceTask
- Finish the ExternalTask with `{}`, `null` or `undefined`
- Notice that the ServiceTask`s `onExit` token will always be `{}`