### PR TITLE
 🐛 Fix BoundaryEvent state transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -697,15 +697,15 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.15.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-beta.2.tgz",
-      "integrity": "sha512-udYUg48v/n8XOWsE8roy8qOsuzSDp/NUJoJ2Doh3sY/rJjxFveF1+HMYEbhwy2nOCimD7lwHS2JaGCpL6m8Yjw==",
+      "version": "12.15.0-feature-6b4bd3-k5z6nw73",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-6b4bd3-k5z6nw73.tgz",
+      "integrity": "sha512-faYyGSP0KidAdroZ5ggNy2QjaG7TG3ySdimTtASHqNWGIcagnHLTi1jTVCNcCs/m7caZuenGCqRlWSw5+Hqq9w==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
         "@process-engine/logging_api_contracts": "^2.0.0",
         "@process-engine/persistence_api.contracts": "^1.3.0",
-        "@process-engine/process_engine_contracts": "^46.1.0",
+        "@process-engine/process_engine_contracts": "47.0.0-alpha.3",
         "@types/clone": "^0.1.30",
         "@types/socket.io": "^2.1.2",
         "addict-ioc": "^2.5.1",
@@ -718,6 +718,17 @@
         "node-uuid": "^1.4.8",
         "should": "^13.2.3",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "@process-engine/process_engine_contracts": {
+          "version": "47.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-47.0.0-alpha.3.tgz",
+          "integrity": "sha512-aKUuP2vK1cOavQzc7S2qZlUK/gVDwCfZw+NyUpA9ASQbDxaKlS8FWaOShG7eH67Vud1aq+Fj3xRick0ThMQfsQ==",
+          "requires": {
+            "@essential-projects/event_aggregator_contracts": "^4.0.0",
+            "@essential-projects/iam_contracts": "^3.4.2"
+          }
+        }
       }
     },
     "@types/bluebird": {
@@ -745,9 +756,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-          "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+          "version": "13.5.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
         }
       }
     },
@@ -779,9 +790,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-          "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+          "version": "13.5.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
         }
       }
     },
@@ -794,9 +805,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-          "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+          "version": "13.5.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
         }
       }
     },
@@ -841,9 +852,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-          "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+          "version": "13.5.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
         }
       }
     },
@@ -856,9 +867,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-          "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+          "version": "13.5.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
         }
       }
     },
@@ -912,9 +923,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.25.tgz",
-      "integrity": "sha512-nf1LMGZvgFX186geVZR1xMZKKblJiRfiASTHw85zED2kI1yDKHDwTKMdkaCbTlXoRKlGKaDfYywt+V0As30q3w==",
+      "version": "12.12.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.26.tgz",
+      "integrity": "sha512-UmUm94/QZvU5xLcUlNR8hA7Ac+fGpO1EG/a8bcWVz0P0LqtxFmun9Y2bbtuckwGboWJIT70DoWq1r3hb56n3DA==",
       "dev": true
     },
     "@types/range-parser": {
@@ -952,9 +963,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-          "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+          "version": "13.5.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
         }
       }
     },
@@ -1397,9 +1408,9 @@
       }
     },
     "bowser": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.8.1.tgz",
-      "integrity": "sha512-FxxltGKqMHkVa3KtpA+kdnxH0caHPDewccyrK3vW1bsMw6Zco4vRPmMunowX0pXlDZqhxkKSpToADQI2Sk4OeQ=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.9.0.tgz",
+      "integrity": "sha512-2ld76tuLBNFekRgmJfT2+3j5MIrP6bFict8WAIT3beq+srz1gcKNAdNKMqHqauQt63NmAa88HfP1/Ypa9Er3HA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -6292,9 +6303,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-          "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ=="
+          "version": "13.5.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -697,9 +697,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.15.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-beta.3.tgz",
-      "integrity": "sha512-IqrVtABMBIHkKDRh3uqQvyEpRaQn4/gM9mYar3p9knw0Ix8aL8NWG4YUHcVu0BZrbYzcLJblD/K0TDt7Y+PleQ==",
+      "version": "12.15.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-beta.4.tgz",
+      "integrity": "sha512-Il3UoiSj8O7mj4XAPZiSrwHA7QMAB9hZCTWb/cGTuocRSPgnw8b2EzXcmFt2QvVnlILv6MOHNJPwGDHBDEIM5Q==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -697,9 +697,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.15.0-feature-a2cdd2-k5z8lp0a",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-a2cdd2-k5z8lp0a.tgz",
-      "integrity": "sha512-Lkr5V982Hyx+GfyozcylT1TXJpsGDMblqt+0zKnUJwXsH3FTaPVcrY3JmvRvq7legmQPQ3OyaSjzqn0h/Kzqjg==",
+      "version": "12.15.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-beta.3.tgz",
+      "integrity": "sha512-IqrVtABMBIHkKDRh3uqQvyEpRaQn4/gM9mYar3p9knw0Ix8aL8NWG4YUHcVu0BZrbYzcLJblD/K0TDt7Y+PleQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -697,9 +697,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.15.0-feature-6b4bd3-k5z6nw73",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-6b4bd3-k5z6nw73.tgz",
-      "integrity": "sha512-faYyGSP0KidAdroZ5ggNy2QjaG7TG3ySdimTtASHqNWGIcagnHLTi1jTVCNcCs/m7caZuenGCqRlWSw5+Hqq9w==",
+      "version": "12.15.0-feature-a2cdd2-k5z8lp0a",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.15.0-feature-a2cdd2-k5z8lp0a.tgz",
+      "integrity": "sha512-Lkr5V982Hyx+GfyozcylT1TXJpsGDMblqt+0zKnUJwXsH3FTaPVcrY3JmvRvq7legmQPQ3OyaSjzqn0h/Kzqjg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.4.0-beta.1",
     "@process-engine/persistence_api.services": "1.4.0-beta.1",
     "@process-engine/persistence_api.use_cases": "1.4.0-beta.1",
-    "@process-engine/process_engine_core": "feature~fix_external_task_decoration",
+    "@process-engine/process_engine_core": "12.15.0-beta.3",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.4.0-beta.1",
     "@process-engine/persistence_api.services": "1.4.0-beta.1",
     "@process-engine/persistence_api.use_cases": "1.4.0-beta.1",
-    "@process-engine/process_engine_core": "12.15.0-beta.2",
+    "@process-engine/process_engine_core": "feature~fix_external_task_decoration",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.4.0-beta.1",
     "@process-engine/persistence_api.services": "1.4.0-beta.1",
     "@process-engine/persistence_api.use_cases": "1.4.0-beta.1",
-    "@process-engine/process_engine_core": "12.15.0-beta.3",
+    "@process-engine/process_engine_core": "12.15.0-beta.4",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.3",


### PR DESCRIPTION
## Changes

1. Detach BoundaryEvents prior to running `afterExecute` cleanup on decorated Activities
2. Implement resumption for BoundaryEventHandlers
3. When resuming a decorated activity, all attached BoundaryEvents will now be resumed, instead of executed
    - This fixes the issue with multiple `onEnter` tokens for a single BoundaryEvent
4. Fix some null reference issues on the base ActivityHandler
5. Unsubscribe from `ExternalTaskFinished` event, when an `ExternalServiceTaskHandler` gets interruped
6. Fix BoundaryEvents token production
    - Each BoundaryEvent should now always produce an `onExit` token, either when trigger, or when the activity finishes and removes its BoundaryEvents
7. Refine resumption of ProcessInstances. A ProcessInstance is now considered to be orphaned, if it:
    - is in a running state
    - has no active FlowNodeInstances
    - has reached at least one EndEvent
8. ProcessInstances that were in a running state, have no active FlowNodeInstances, but have not yet reached an EndEvent are regarded as interrupted and will be resumed regularly.
9. CorrelationIds for ProcessInstances started by a cronjob now use UUIDs with a "cronjob" prefix (i.e.: `cronjob_[SOME_UUID]`) 

## Issues

Closes #509 
Closes #510

PR: #511

## How to test the changes

To check the BoundaryEvents:

- Run a Process that uses decorated activities
    - easiest would be a UserTask or an external ServiceTask because they do not automatically resume
- Decorate these activities with either:
    - `TimerBoundaryEvent`
    - `MessageBoundaryEvent`
    - `SignalBoundaryEvent`
- Trigger the BoundaryEvent 
    - Messages and Signals can be easily triggered through a separate process that uses IntermediateEvents or dedicated EndEvents
- See that the decorated activity cancels execution
- See that the process now follows the path marked by the BoundaryEvent
- See that the BoundaryEvent instance has produced only one `onEnter` and one `onExit` token

To check the resumption of ProcessInstances:

**Note:** The changes described in the following steps have to be performed manually in your database.

1.
    Run a ProcessInstance and finish it (A ProcessModel with StartEvent -> ScriptTask -> EndEvent is sufficient for this)
    Change the state of the ProcessInstance to running
    Manually remove the FlowNodeInstance of the EndEvent
    Change the state of the ScriptTask to "running" and remove the "onExit" token
    The ProcessInstance will be resumed until the EndEvent is reached

2.
    Run a ProcessInstance and finish it
    Change the state of the ProcessInstance to running
    Manually remove the FlowNodeInstance of the EndEvent
    Do NOT modify any of the other FlowNodeInstances
    The ProcessInstance will be resumed until the EndEvent is reached

3.
    Run a ProcessInstance and finish it
    Change the state of the ProcessInstance to running
    Do NOT modify any of the FlowNodeInstances
    The ProcessInstance will be regared as orphaned. It will be put into a "finished" state