### PR TITLE
🐛 Fix process instance public type conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.4.0-alpha.11",
+  "version": "9.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,15 +38,15 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-      "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-      "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+      "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -362,9 +362,9 @@
       }
     },
     "@process-engine/consumer_api_core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_core/-/consumer_api_core-6.3.0.tgz",
-      "integrity": "sha512-GXXLGVC4rh33gjwAW6twck8j2v9+UBwt2xAlmG/KSq2NWvwx8UGfKkOqegMPjfWaZNsyob/AaC8SBioEikaJJg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_core/-/consumer_api_core-6.3.1.tgz",
+      "integrity": "sha512-kyIE5jcUn/BIhIEbWTD9Ss6C2KpL8zKBPM2GyfvTV+4XN0QuLeAQQjlO+ehiAvjHyqjdjy1K9Gwc89Dkc2bIng==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@process-engine/consumer_api_contracts": "^9.2.0",
@@ -501,21 +501,32 @@
       }
     },
     "@process-engine/management_api_core": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.3.0.tgz",
-      "integrity": "sha512-XGvdiWId9vby5s8GrkN/QwR9OGJ1srSsgjMdGqefaAWkl5r4xOysA+1Vm1kX6vaA1ZqNvS7vdI9EDyTecBN+kw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/management_api_core/-/management_api_core-6.3.1.tgz",
+      "integrity": "sha512-yKRuLq4jEAIpxQMoUtQxFMHrs0DgFRnLLAvAT7QqEL9ygLtwP3xM9ht3HQTXl1tjnpYxgxXg6ayVX6wGuUQxDg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@process-engine/logging_api_contracts": "^2.0.0",
         "@process-engine/management_api_contracts": "^13.2.0",
         "@process-engine/persistence_api.contracts": "^1.3.0",
-        "@process-engine/process_engine_contracts": "^46.1.0",
+        "@process-engine/process_engine_contracts": "^47.0.0",
         "bluebird": "^3.5.2",
         "bluebird-global": "^1.0.1",
         "clone": "^2.1.2",
         "loggerhythm": "^3.0.3",
         "moment": "^2.24.0",
         "node-uuid": "^1.4.8"
+      },
+      "dependencies": {
+        "@process-engine/process_engine_contracts": {
+          "version": "47.0.0",
+          "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-47.0.0.tgz",
+          "integrity": "sha512-3tN4BLuqsIaQmn66XlVw54w/M1cMxyEXLNNhT1aRVEpKIfOQ7CGHCVgHxuY3uevNhwUdexi3fVaN82u7Ef1bQw==",
+          "requires": {
+            "@essential-projects/event_aggregator_contracts": "^4.0.0",
+            "@essential-projects/iam_contracts": "^3.4.2"
+          }
+        }
       }
     },
     "@process-engine/management_api_http": {
@@ -609,6 +620,7 @@
       "version": "46.1.0",
       "resolved": "https://registry.npmjs.org/@process-engine/process_engine_contracts/-/process_engine_contracts-46.1.0.tgz",
       "integrity": "sha512-85ePSLmmsHblFKYHUcidOYt0Z0OxAP5g5hX9ixRU3jvJYSS0heQg5HcRk3QAuQSX/PoauD2bzQxOjX5goRUjlA==",
+      "dev": true,
       "requires": {
         "@essential-projects/event_aggregator_contracts": "^4.0.0",
         "@essential-projects/iam_contracts": "^3.4.2"
@@ -674,9 +686,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+          "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
         }
       }
     },
@@ -708,9 +720,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+          "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
         }
       }
     },
@@ -723,9 +735,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+          "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
         }
       }
     },
@@ -770,9 +782,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+          "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
         }
       }
     },
@@ -785,9 +797,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+          "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
         }
       }
     },
@@ -881,9 +893,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+          "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
         }
       }
     },
@@ -926,12 +938,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.18.0.tgz",
-      "integrity": "sha512-kuO8WQjV+RCZvAXVRJfXWiJ8iYEtfHlKgcqqqXg9uUkIolEHuUaMmm8/lcO4xwCOtaw6mY0gStn2Lg4/eUXXYQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.19.0.tgz",
+      "integrity": "sha512-u7IcQ9qwsB6U806LupZmINRnQjC+RJyv36sV/ugaFWMHTbFm/hlLTRx3gGYJgHisxcGSTnf+I/fPDieRMhPSQQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.18.0",
+        "@typescript-eslint/experimental-utils": "2.19.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -939,32 +951,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.18.0.tgz",
-      "integrity": "sha512-J6MopKPHuJYmQUkANLip7g9I82ZLe1naCbxZZW3O2sIxTiq/9YYoOELEKY7oPg0hJ0V/AQ225h2z0Yp+RRMXhw==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.0.tgz",
+      "integrity": "sha512-zwpg6zEOPbhB3+GaQfufzlMUOO6GXCNZq6skk+b2ZkZAIoBhVoanWK255BS1g5x9bMwHpLhX0Rpn5Fc3NdCZdg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.18.0",
+        "@typescript-eslint/typescript-estree": "2.19.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.18.0.tgz",
-      "integrity": "sha512-SJJPxFMEYEWkM6pGfcnjLU+NJIPo+Ko1QrCBL+i0+zV30ggLD90huEmMMhKLHBpESWy9lVEeWlQibweNQzyc+A==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.19.0.tgz",
+      "integrity": "sha512-s0jZoxAWjHnuidbbN7aA+BFVXn4TCcxEVGPV8lWMxZglSs3NRnFFAlL+aIENNmzB2/1jUJuySi6GiM6uACPmpg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.18.0",
-        "@typescript-eslint/typescript-estree": "2.18.0",
+        "@typescript-eslint/experimental-utils": "2.19.0",
+        "@typescript-eslint/typescript-estree": "2.19.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.18.0.tgz",
-      "integrity": "sha512-gVHylf7FDb8VSi2ypFuEL3hOtoC4HkZZ5dOjXvVjoyKdRrvXAOPSzpNRnKMfaUUEiSLP8UF9j9X9EDLxC0lfZg==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.19.0.tgz",
+      "integrity": "sha512-n6/Xa37k0jQdwpUszffi19AlNbVCR0sdvCs3DmSKMD7wBttKY31lhD2fug5kMD91B2qW4mQldaTEc1PEzvGu8w==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -2293,9 +2305,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.0.tgz",
-      "integrity": "sha512-NK42oA0mUc8Ngn4kONOPsPB1XhbUvNHqF+g307dPV28aknPoiNnKLFd9em4nkswwepdF5ouieqv5Th/63U7YJQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
+      "integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -4280,9 +4292,9 @@
       }
     },
     "needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.2.tgz",
+      "integrity": "sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -4769,15 +4781,15 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.17.1.tgz",
-      "integrity": "sha512-SYWEip6eADsgDQIZk0bmB2JDOrC8Xu6z10KlhlXl03NSomwVmHB6ZTVyDCwOfT6bXHI8QndJdk5XxSSRXikaSA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-7.18.1.tgz",
+      "integrity": "sha512-1KtKBKg/zWrjEEv//klBbVOPGucuc7HHeJf6OEMueVcUeyF3yueHf+DvhVwBjIAe9/97RAydO/lWjkcMwssuEw==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
         "pg-connection-string": "0.1.3",
         "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.9",
+        "pg-pool": "^2.0.10",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -4814,9 +4826,9 @@
       "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
     },
     "pg-pool": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.9.tgz",
-      "integrity": "sha512-gNiuIEKNCT3OnudQM2kvgSnXsLkSpd6mS/fRnqs6ANtrke6j8OY5l9mnAryf1kgwJMWLg0C1N1cYTZG1xmEYHQ=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -6052,9 +6064,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
-      "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.7.tgz",
+      "integrity": "sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==",
       "optional": true,
       "requires": {
         "commander": "~2.20.3",
@@ -6221,9 +6233,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.5.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-          "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA=="
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+          "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Standalone application that provides access to the .TS implementation of the ProcessEngine.",
   "bin": {
     "process-engine": "./bin/index.js"
@@ -75,12 +75,12 @@
     "@essential-projects/http": "2.5.0",
     "@essential-projects/http_extension": "7.1.0",
     "@essential-projects/timing": "5.0.2",
-    "@process-engine/consumer_api_core": "6.3.0",
+    "@process-engine/consumer_api_core": "6.3.1",
     "@process-engine/consumer_api_http": "5.3.0",
     "@process-engine/iam": "1.7.4",
     "@process-engine/logging_api_core": "2.0.1",
     "@process-engine/logging.repository.file_system": "2.0.1",
-    "@process-engine/management_api_core": "6.3.0",
+    "@process-engine/management_api_core": "6.3.1",
     "@process-engine/management_api_http": "5.2.0",
     "@process-engine/persistence_api.repositories.sequelize": "1.4.0",
     "@process-engine/persistence_api.services": "1.4.0",

--- a/test/3_consumer_api/process_instances/get_running_instances_for_identity.js
+++ b/test/3_consumer_api/process_instances/get_running_instances_for_identity.js
@@ -15,7 +15,6 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
   let secondaryIdentity;
   let restrictedIdentity;
 
-  const correlationId = uuid.v4();
   const processModelId = 'test_consumer_api_usertask';
 
   before(async () => {
@@ -36,6 +35,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
   });
 
   describe('Execution', () => {
+    const correlationId = uuid.v4();
 
     before(async () => {
       await processInstanceHandler.startProcessInstanceAndReturnCorrelationId(processModelId, correlationId);
@@ -100,7 +100,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
     before(async () => {
       // Create a number of ProcessInstances so we can actually test the pagination.
       const correlationId = uuid.v4();
-      for(let i = 0; i < 10; i++) {
+      for (let i = 0; i < 10; i++) {
         await processInstanceHandler.startProcessInstanceAndReturnCorrelationId(processModelId, correlationId, undefined, secondaryIdentity);
       }
       await processInstanceHandler.waitForProcessInstanceToReachSuspendedTask(correlationId, processModelId, 10);

--- a/test/3_consumer_api/process_instances/get_running_instances_for_identity.js
+++ b/test/3_consumer_api/process_instances/get_running_instances_for_identity.js
@@ -15,6 +15,7 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
   let secondaryIdentity;
   let restrictedIdentity;
 
+  const correlationId = uuid.v4();
   const processModelId = 'test_consumer_api_usertask';
 
   before(async () => {
@@ -37,7 +38,6 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
   describe('Execution', () => {
 
     before(async () => {
-      const correlationId = uuid.v4();
       await processInstanceHandler.startProcessInstanceAndReturnCorrelationId(processModelId, correlationId);
       await processInstanceHandler.waitForProcessInstanceToReachSuspendedTask(correlationId);
     });
@@ -56,9 +56,9 @@ describe('ConsumerAPI: GetProcessInstancesByIdentity', () => {
 
       for (const processInstance of processInstances) {
         should(processInstance).have.property('id');
-        should(processInstance).have.property('correlationId');
-        should(processInstance).have.property('processModelId');
         should(processInstance).have.property('owner');
+        should(processInstance.correlationId).be.equal(correlationId);
+        should(processInstance.processModelId).be.equal(processModelId);
 
         const decodedRequestingIdentity = jsonwebtoken.decode(processInstance.owner.token);
         const decodedProcessInstanceIdentity = jsonwebtoken.decode(defaultIdentity.token);


### PR DESCRIPTION
## Changes

Fix an issue, where ProcessInstances retrieved through the ConsumerAPI would have their values for `correlationId` and `processModelId` switched.

## Issues

Closes #514 

PR: #515

## How to test the changes

- Start a few ProcessInstances
- Retrieve them through the Consumer API, using `getProcessInstancesByIdentity`
- See that all properties are as expected