### PR TITLE
🔊 http prefix for url info

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -370,6 +370,11 @@ function printHttpInfo(): void {
   const configuredAddress = process.env.http__http_extension__server__host ?? httpConfig.server.host;
   const configuredPort = process.env.http__http_extension__server__port ?? httpConfig.server.port;
 
-  logger.info(`Using HTTP endpoint ${configuredAddress}:${configuredPort}`);
-  logger.info(`Using websocket endpoint ${configuredAddress}:${configuredPort}`);
+  const addressHasHttpPrefix = configuredAddress.startsWith('http://') || configuredAddress.startsWith('https://');
+  const showcaseHttpAddress = addressHasHttpPrefix
+    ? configuredAddress
+    : `http://${configuredAddress}`;
+
+  logger.info(`Using HTTP endpoint ${showcaseHttpAddress}:${configuredPort}`);
+  logger.info(`Using websocket endpoint ${showcaseHttpAddress}:${configuredPort}`);
 }

--- a/src/modules/console_interface.ts
+++ b/src/modules/console_interface.ts
@@ -83,8 +83,13 @@ function printHttpInfo(): void {
 
     const httpInfo = (httpExtension.httpServer.address() as AddressInfo);
 
+    const addressHasHttpPrefix = httpInfo.address.startsWith('http://') || httpInfo.address.startsWith('https://');
+    const showcaseHttpAddress = addressHasHttpPrefix
+      ? httpInfo.address
+      : `http://${httpInfo.address}`;
+
     console.log('');
-    console.log(chalk.blueBright('Http address: '), httpInfo.address);
+    console.log(chalk.blueBright('Http address: '), showcaseHttpAddress);
     console.log(chalk.blueBright('Http port: '), httpInfo.port);
     console.log(chalk.blueBright('IP protocol: '), httpInfo.family);
     console.log('');


### PR DESCRIPTION
## Changes

1. Ensure a `http://` prefix is printed with the configured urls at startup
2. Ensure a `http://` prefix is printed with the output of the `httpconfig` command

## Issues

Closes #529

PR: #530

## How to test the changes

- Start the application

See this output:
![Bildschirmfoto 2020-02-25 um 08 32 14](https://user-images.githubusercontent.com/15343316/75224913-c128fd80-57a9-11ea-8872-5d7f83a8d233.png)


- Type `httpconfig`

Get this output:

![Bildschirmfoto 2020-02-25 um 08 32 24](https://user-images.githubusercontent.com/15343316/75224934-cd14bf80-57a9-11ea-8e04-4176db5cd477.png)
