### PR TITLE
♻️ Mark api/external_task/v1 routes as deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.5.0-alpha.8",
+  "version": "9.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -378,14 +378,14 @@
       }
     },
     "@process-engine/consumer_api_http": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_http/-/consumer_api_http-5.4.0.tgz",
-      "integrity": "sha512-6aeJWVVPuD4+3HXtGppr4qc/sdw9AbqKAmfFwduq3L9m2oywEAEBdq5+BomhHO17wHfzTy1/XIWVVJm2QTjqbA==",
+      "version": "5.5.0-feature-44ef90-k7n6cxuw",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_http/-/consumer_api_http-5.5.0-feature-44ef90-k7n6cxuw.tgz",
+      "integrity": "sha512-2jX2uSqzcirey/1e5oIuQd7I1xZqiNUQ/zSU6wAR/JRqSE1ymqvagmY2varRkWMzqIXH156hYCCzRdkRNsEXKA==",
       "requires": {
         "@essential-projects/bootstrapper_contracts": "^1.4.0",
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/event_aggregator_contracts": "^4.1.0",
-        "@essential-projects/http_contracts": "^2.4.0",
+        "@essential-projects/http_contracts": "^2.6.0-27f0e99a-b1",
         "@essential-projects/http_node": "^4.2.0",
         "@essential-projects/iam_contracts": "^3.5.0",
         "@process-engine/consumer_api_contracts": "^10.0.0",
@@ -393,6 +393,21 @@
         "loggerhythm": "^3.0.3",
         "openapi-doc": "^4.1.6",
         "socket.io": "^2.2.0"
+      },
+      "dependencies": {
+        "@essential-projects/http_contracts": {
+          "version": "2.6.0-27f0e99a-b1",
+          "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.6.0-27f0e99a-b1.tgz",
+          "integrity": "sha512-iW2y2l6Ff/+cOIYrS+/Bj7YykKh9mhWeZYaxaKFsmg6eXBTuNWUEHgy6ztxz3DYVXqbpuEScrRZwSpkjPd0eFw==",
+          "requires": {
+            "@essential-projects/errors_ts": "^1.5.2",
+            "@essential-projects/iam_contracts": "^3.5.0",
+            "@types/express": "^4.16.0",
+            "@types/socket.io": "^2.1.0",
+            "loggerhythm": "^3.0.4",
+            "popsicle": "^10.0.0"
+          }
+        }
       }
     },
     "@process-engine/external_task_api_client": {
@@ -921,12 +936,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.22.0.tgz",
-      "integrity": "sha512-BvxRLaTDVQ3N+Qq8BivLiE9akQLAOUfxNHIEhedOcg8B2+jY8Rc4/D+iVprvuMX1AdezFYautuGDwr9QxqSxBQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.23.0.tgz",
+      "integrity": "sha512-8iA4FvRsz8qTjR0L/nK9RcRUN3QtIHQiOm69FzV7WS3SE+7P7DyGGwh3k4UNR2JBbk+Ej2Io+jLAaqKibNhmtw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.22.0",
+        "@typescript-eslint/experimental-utils": "2.23.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -934,32 +949,32 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.22.0.tgz",
-      "integrity": "sha512-sJt1GYBe6yC0dWOQzXlp+tiuGglNhJC9eXZeC8GBVH98Zv9jtatccuhz0OF5kC/DwChqsNfghHx7OlIDQjNYAQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz",
+      "integrity": "sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.22.0",
+        "@typescript-eslint/typescript-estree": "2.23.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.22.0.tgz",
-      "integrity": "sha512-FaZKC1X+nvD7qMPqKFUYHz3H0TAioSVFGvG29f796Nc5tBluoqfHgLbSFKsh7mKjRoeTm8J9WX2Wo9EyZWjG7w==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.23.0.tgz",
+      "integrity": "sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.22.0",
-        "@typescript-eslint/typescript-estree": "2.22.0",
+        "@typescript-eslint/experimental-utils": "2.23.0",
+        "@typescript-eslint/typescript-estree": "2.23.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.22.0.tgz",
-      "integrity": "sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz",
+      "integrity": "sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -2406,12 +2421,12 @@
       "dev": true
     },
     "espree": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-      "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
+        "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
@@ -3262,9 +3277,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-      "integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -3859,9 +3874,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
+      "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -6297,9 +6312,9 @@
       }
     },
     "ws": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.2.tgz",
-      "integrity": "sha512-2qj/tYkDPDSVf7JiHanwEBwkhxi7DchFewIsSnR33MQtG3O/BPAJjqs4g6XEuayuRqIExSQMHZlmyDLbuSrXYw=="
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
     },
     "x-xss-protection": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,9 +142,9 @@
       }
     },
     "@essential-projects/http_contracts": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.5.1.tgz",
-      "integrity": "sha512-EGLkmLfi14MKZ4xlCcOSSoGGSqW1Zl80DEnTlzlZqpzLjNwISWk1YZPYrj5178kzxxaSIS3WWp0+kSsi0cOG9g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.6.0.tgz",
+      "integrity": "sha512-+kFqiq7zbLpVD/gtc+q+FkRNf3glLOSUZ8S9HJo/UBlZ+7TrTW99lr/wrwdFk8VCSMdDh1sYJ3yWF6VnoMIkWg==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.2",
         "@essential-projects/iam_contracts": "^3.5.0",
@@ -378,14 +378,14 @@
       }
     },
     "@process-engine/consumer_api_http": {
-      "version": "5.5.0-feature-44ef90-k7n6cxuw",
-      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_http/-/consumer_api_http-5.5.0-feature-44ef90-k7n6cxuw.tgz",
-      "integrity": "sha512-2jX2uSqzcirey/1e5oIuQd7I1xZqiNUQ/zSU6wAR/JRqSE1ymqvagmY2varRkWMzqIXH156hYCCzRdkRNsEXKA==",
+      "version": "5.5.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/consumer_api_http/-/consumer_api_http-5.5.0-alpha.1.tgz",
+      "integrity": "sha512-D+wdJxOBfdLEV+sDm+9ISx2NzKADwWrGvrYrlBSURsSzzdw03WIAKp9ENoeAPeXY1GCM2ZdLzrK0PQ89Tk0rvA==",
       "requires": {
         "@essential-projects/bootstrapper_contracts": "^1.4.0",
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/event_aggregator_contracts": "^4.1.0",
-        "@essential-projects/http_contracts": "^2.6.0-27f0e99a-b1",
+        "@essential-projects/http_contracts": "^2.6.0",
         "@essential-projects/http_node": "^4.2.0",
         "@essential-projects/iam_contracts": "^3.5.0",
         "@process-engine/consumer_api_contracts": "^10.0.0",
@@ -393,21 +393,6 @@
         "loggerhythm": "^3.0.3",
         "openapi-doc": "^4.1.6",
         "socket.io": "^2.2.0"
-      },
-      "dependencies": {
-        "@essential-projects/http_contracts": {
-          "version": "2.6.0-27f0e99a-b1",
-          "resolved": "https://registry.npmjs.org/@essential-projects/http_contracts/-/http_contracts-2.6.0-27f0e99a-b1.tgz",
-          "integrity": "sha512-iW2y2l6Ff/+cOIYrS+/Bj7YykKh9mhWeZYaxaKFsmg6eXBTuNWUEHgy6ztxz3DYVXqbpuEScrRZwSpkjPd0eFw==",
-          "requires": {
-            "@essential-projects/errors_ts": "^1.5.2",
-            "@essential-projects/iam_contracts": "^3.5.0",
-            "@types/express": "^4.16.0",
-            "@types/socket.io": "^2.1.0",
-            "loggerhythm": "^3.0.4",
-            "popsicle": "^10.0.0"
-          }
-        }
       }
     },
     "@process-engine/external_task_api_client": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@essential-projects/http_extension": "7.1.0",
     "@essential-projects/timing": "5.0.2",
     "@process-engine/consumer_api_core": "6.4.0",
-    "@process-engine/consumer_api_http": "feature~mark_external_task_routes_as_deprecated",
+    "@process-engine/consumer_api_http": "5.5.0-alpha.1",
     "@process-engine/iam": "1.7.4",
     "@process-engine/logging_api_core": "2.0.1",
     "@process-engine/logging.repository.file_system": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@essential-projects/http_extension": "7.1.0",
     "@essential-projects/timing": "5.0.2",
     "@process-engine/consumer_api_core": "6.4.0",
-    "@process-engine/consumer_api_http": "5.4.0",
+    "@process-engine/consumer_api_http": "feature~mark_external_task_routes_as_deprecated",
     "@process-engine/iam": "1.7.4",
     "@process-engine/logging_api_core": "2.0.1",
     "@process-engine/logging.repository.file_system": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/process_engine_runtime",
-  "version": "9.5.0",
+  "version": "9.6.0",
   "description": "Standalone application that provides access to the .TS implementation of the ProcessEngine.",
   "bin": {
     "process-engine": "./bin/index.js"


### PR DESCRIPTION
## Changes

Add `depcreated` warning to all obsolete `api/external_task/v1` routes.

## Issues

Closes #533

PR: #535

## How to test the changes

- Try accessing any of the old `api/external_task/v1`
- See that you'll get a deprecation warning printed to the console
- Also notice that the response headers will contain values for `Deprecated` and `Link`

Example:

![Bildschirmfoto 2020-03-11 um 11 30 21](https://user-images.githubusercontent.com/15343316/76407495-b797bc00-638b-11ea-97d1-d4cfc15e75a0.png)
