### PR TITLE
✨ Retry send task

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,9 +3,17 @@
   "rules": {
     "no-console": "off",
     "no-plusplus": "off",
-    "strict": "off",
-    "@typescript-eslint/no-require-imports": "off",
-    "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/prefer-for-of": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {
+        "strict": "off",
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/no-require-imports": "off",
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    }
+  ]
 }

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -105,19 +105,11 @@ jobs:
     needs: prepare_version
     runs-on: ubuntu-18.04
 
-    services:
-      postgres:
-        image: postgres:11
-        env:
-          POSTGRES_USER: admin
-          POSTGRES_PASSWORD: admin
-          POSTGRES_DB: processengine
-        ports:
-        - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
     steps:
     - uses: actions/checkout@v1
+
+    - name: Setup Postgres Container
+      run: node scripts/setup_postgres/postgres_docker.js start
 
     - name: Unstash package.json
       uses: actions/download-artifact@master

--- a/bpmn/send_task_max_retry_test.bpmn
+++ b/bpmn/send_task_max_retry_test.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definition_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="BPMN Studio" exporterVersion="1">
+  <bpmn:collaboration id="Collaboration_1cidyxu" name="">
+    <bpmn:participant id="Participant_0px403d" name="send_task_max_retry_test" processRef="send_task_max_retry_test" />
+  </bpmn:collaboration>
+  <bpmn:process id="send_task_max_retry_test" name="send_task_max_retry_test" isExecutable="true">
+    <bpmn:laneSet>
+      <bpmn:lane id="Lane_1xzf0d3" name="Default_Test_Lane">
+        <bpmn:flowNodeRef>StartEvent_1mox3jl</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndEvent_0eie6q6</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Task_1i7z5sv</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent_1mox3jl" name="Start Event">
+      <bpmn:outgoing>SequenceFlow_1jdocur</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1jdocur" sourceRef="StartEvent_1mox3jl" targetRef="Task_1i7z5sv" />
+    <bpmn:endEvent id="EndEvent_0eie6q6" name="End Event">
+      <bpmn:incoming>SequenceFlow_0tajbqa</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0tajbqa" sourceRef="Task_1i7z5sv" targetRef="EndEvent_0eie6q6" />
+    <bpmn:sendTask id="Task_1i7z5sv" name="Abort after 5 retries with 100ms interval" messageRef="Message_pXd5XBZU">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="maxRetries" value="5" />
+          <camunda:property name="retryIntervalInMs" value="100" />
+        </camunda:properties>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1jdocur</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0tajbqa</bpmn:outgoing>
+    </bpmn:sendTask>
+  </bpmn:process>
+  <bpmn:message id="Message_pXd5XBZU" name="AMessageThatNeverComes" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cidyxu">
+      <bpmndi:BPMNShape id="Participant_0px403d_di" bpmnElement="Participant_0px403d">
+        <dc:Bounds x="5" y="4" width="581" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1xzf0d3_di" bpmnElement="Lane_1xzf0d3">
+        <dc:Bounds x="35" y="4" width="551" height="170" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1mox3jl_di" bpmnElement="StartEvent_1mox3jl">
+        <dc:Bounds x="83" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0eie6q6_di" bpmnElement="EndEvent_0eie6q6">
+        <dc:Bounds x="503" y="69" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jdocur_di" bpmnElement="SequenceFlow_1jdocur">
+        <di:waypoint x="119" y="87" />
+        <di:waypoint x="237" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0tajbqa_di" bpmnElement="SequenceFlow_0tajbqa">
+        <di:waypoint x="337" y="87" />
+        <di:waypoint x="503" y="87" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="SendTask_07l768x_di" bpmnElement="Task_1i7z5sv">
+        <dc:Bounds x="237" y="47" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/package-lock.json
+++ b/package-lock.json
@@ -643,9 +643,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.16.2-feature-a95cd7-k7q6zfld",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.16.2-feature-a95cd7-k7q6zfld.tgz",
-      "integrity": "sha512-dGg653rTGU+xQESWvgaYhzllF6IUQbEk3CLCe04VVRr49fiCAgpWf8KL5Be8dOwB0/4JfC1DUusq0H8eK3gZEQ==",
+      "version": "12.17.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.17.0-alpha.1.tgz",
+      "integrity": "sha512-gztC9RDXnh5teqPrKxuhbaKN6pK9QbA7To6Y9f16I9JDAC5YXN0ibg1X5oAJ5Cotpd5PDEhytjT+xDpKazJKIw==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
@@ -816,9 +816,9 @@
       "dev": true
     },
     "@types/methods": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.0.tgz",
-      "integrity": "sha512-ROomEm+QHlUmcQoDr3CBo3GRm0w4PVoFYjVT9YcfyBha/Per4deb1IpvHU7KTK7YBZCIvOYbSADoEyDnFgaWLA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.1.tgz",
+      "integrity": "sha512-hvD1Yz0xugpvbFNVihc0Eu60Y/o1dD8LmSdN4d5QHV315ljuVGlwS5DYrb3RqFi6JskDC0Xi6/Bv6aEe/1A9bw=="
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -1734,16 +1734,16 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-parser": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
-      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
       "requires": {
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6"
       }
     },
@@ -1994,6 +1994,11 @@
         "ws": "^7.1.2"
       },
       "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2568,13 +2573,6 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-        }
       }
     },
     "extend": {
@@ -3933,6 +3931,12 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -4099,6 +4103,16 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^13.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -6278,9 +6292,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
@@ -6416,9 +6430,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
@@ -6430,7 +6444,7 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
+            "yargs-parser": "^13.1.2"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-      "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
+      "version": "7.8.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
+      "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
       "dev": true
     },
     "@babel/runtime": {
@@ -53,9 +53,9 @@
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.4",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
           "dev": true
         }
       }
@@ -544,9 +544,9 @@
       }
     },
     "@process-engine/persistence_api.contracts": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.4.1.tgz",
-      "integrity": "sha512-lqNNtm768gSfQ2uj+hIcubbPjLGxqQLO+q1PtR1xRFKHPWoFhm1pcfpIhWmfZM/W9KhlZgxn7Pwg+cTNKSQ5KA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@process-engine/persistence_api.contracts/-/persistence_api.contracts-1.4.2.tgz",
+      "integrity": "sha512-/Lurck1R7GD8ynnQgKNlV8nNcrZUHhyjRtg8ANwbQK6q5+OaIqVnS3wtEjViRAyg79nzw54zDv7h0rYYLFGkEw==",
       "requires": {
         "@essential-projects/iam_contracts": "^3.4.1"
       }
@@ -643,9 +643,9 @@
       }
     },
     "@process-engine/process_engine_core": {
-      "version": "12.16.2",
-      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.16.2.tgz",
-      "integrity": "sha512-Q9jSS8VJwQEGOue+UPDDgu+1g6txOVDYw3prMckZGsDU2ESgoXuVWLJXBD7aWn+FEwPGOIOn88BR3lFMZfhDQg==",
+      "version": "12.16.2-feature-a95cd7-k7q6zfld",
+      "resolved": "https://registry.npmjs.org/@process-engine/process_engine_core/-/process_engine_core-12.16.2-feature-a95cd7-k7q6zfld.tgz",
+      "integrity": "sha512-dGg653rTGU+xQESWvgaYhzllF6IUQbEk3CLCe04VVRr49fiCAgpWf8KL5Be8dOwB0/4JfC1DUusq0H8eK3gZEQ==",
       "requires": {
         "@essential-projects/errors_ts": "^1.5.0",
         "@essential-projects/timing_contracts": "^5.0.0",
@@ -692,9 +692,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-          "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+          "version": "13.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
         }
       }
     },
@@ -726,9 +726,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-          "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+          "version": "13.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
         }
       }
     },
@@ -741,9 +741,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-          "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+          "version": "13.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
         }
       }
     },
@@ -782,9 +782,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-          "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+          "version": "13.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
         }
       }
     },
@@ -797,9 +797,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-          "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+          "version": "13.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
         }
       }
     },
@@ -836,9 +836,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.29.tgz",
-      "integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==",
+      "version": "12.12.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
+      "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==",
       "dev": true
     },
     "@types/range-parser": {
@@ -876,9 +876,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-          "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+          "version": "13.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
         }
       }
     },
@@ -3859,9 +3859,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.4.tgz",
-      "integrity": "sha512-wTiNDqe4D2rbTJGZk1qcdZgFtY0/r+iuE6GDT7V0/+Gu5MLpIDm4+CssDECR79OJs/OxLPXMzdxy153b5Qy3hg=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.9.0",
@@ -4099,83 +4099,6 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^13.1.1"
-          }
-        }
-      }
-    },
-    "mocha-jenkins-reporter": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/mocha-jenkins-reporter/-/mocha-jenkins-reporter-0.4.2.tgz",
-      "integrity": "sha512-ofQ41SUX5Uh3eHLn/ki4UTsh/7Yuk6p8N3RbxB275TLPErjkJGXuiT5i0haJ51UdJ+bkUhdyIpcCOHS3XSNVsg==",
-      "dev": true,
-      "requires": {
-        "diff": "4.0.1",
-        "mkdirp": "0.5.1",
-        "mocha": "^5.2.0",
-        "xml": "^1.0.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-          "dev": true
-        },
-        "he": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-          "dev": true
-        },
-        "mocha": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-          "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
-          "dev": true,
-          "requires": {
-            "browser-stdout": "1.3.1",
-            "commander": "2.15.1",
-            "debug": "3.1.0",
-            "diff": "3.5.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.2",
-            "growl": "1.10.5",
-            "he": "1.1.1",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "supports-color": "5.4.0"
-          },
-          "dependencies": {
-            "diff": {
-              "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-              "dev": true
-            }
-          }
-        },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
           }
         }
       }
@@ -6256,9 +6179,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-          "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
+          "version": "13.9.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
+          "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
         }
       }
     },
@@ -6305,12 +6228,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.3.0.tgz",
       "integrity": "sha512-kpyBI9TlVipZO4diReZMAHWtS0MMa/7Kgx8hwG/EuZLiA6sg4Ah/4TRdASHhRRN3boobzcYgFRUFSgHRge6Qhg=="
-    },
-    "xml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
-      "dev": true
     },
     "xml2js": {
       "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.4.2",
     "@process-engine/persistence_api.services": "1.4.1",
     "@process-engine/persistence_api.use_cases": "1.4.0",
-    "@process-engine/process_engine_core": "feature~retry_send_task",
+    "@process-engine/process_engine_core": "12.17.0-alpha.1",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@process-engine/persistence_api.repositories.sequelize": "1.4.2",
     "@process-engine/persistence_api.services": "1.4.1",
     "@process-engine/persistence_api.use_cases": "1.4.0",
-    "@process-engine/process_engine_core": "12.16.2",
+    "@process-engine/process_engine_core": "feature~retry_send_task",
     "@types/socket.io": "^2.1.0",
     "@types/socket.io-client": "^1.4.32",
     "addict-ioc": "^2.5.6",
@@ -128,7 +128,6 @@
     "@types/validator": "^12.0.0",
     "eslint": "^6.8.0",
     "mocha": "^7.0.0",
-    "mocha-jenkins-reporter": "^0.4.1",
     "pkg": "^4.4.3",
     "should": "^13.2.3",
     "typescript": "^3.7.5"

--- a/test/1_process_engine_core/send_task.js
+++ b/test/1_process_engine_core/send_task.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const should = require('should');
+const uuid = require('node-uuid');
+
+const {ProcessInstanceHandler, TestFixtureProvider} = require('../../dist/commonjs/test_setup');
+
+describe('Send Task - ', () => {
+
+  let processInstanceHandler;
+  let testFixtureProvider;
+
+  const processModelSendTask = 'send_task_throw_test';
+  const processModelSendTaskAbort = 'send_task_max_retry_test';
+  const processModelReceiveTask = 'receive_task_wait_test';
+
+  let eventAggregator;
+
+  before(async () => {
+    testFixtureProvider = new TestFixtureProvider();
+    await testFixtureProvider.initializeAndStart();
+
+    await testFixtureProvider.importProcessFiles([
+      processModelSendTask,
+      processModelSendTaskAbort,
+      processModelReceiveTask,
+    ]);
+
+    processInstanceHandler = new ProcessInstanceHandler(testFixtureProvider);
+
+    eventAggregator = await testFixtureProvider.resolveAsync('EventAggregator');
+  });
+
+  after(async () => {
+    await testFixtureProvider.tearDown();
+  });
+
+  it('Should continue Process B with a ReceiveTask, after Process A passed a corresponding SendTask.', async () => {
+    const correlationId = uuid.v4();
+    const endEventToWaitFor = 'EndEvent_1';
+    testFixtureProvider.executeProcess(processModelReceiveTask, 'StartEvent_1', correlationId);
+
+    await processInstanceHandler.waitForProcessInstanceToReachSuspendedTask(correlationId, processModelReceiveTask);
+
+    return new Promise((resolve) => {
+
+      const endMessageReceiveTaskProcess = `/processengine/correlation/${correlationId}/processmodel/${processModelReceiveTask}/ended`;
+      const receiveTaskProcessFinishedCallback = (message) => {
+        const expectedEndEventReached = message.flowNodeId === endEventToWaitFor;
+        if (expectedEndEventReached) {
+          should(message).have.property('currentToken');
+          should(message.currentToken).be.eql('Message Received');
+
+          resolve();
+        }
+      };
+
+      eventAggregator.subscribeOnce(endMessageReceiveTaskProcess, receiveTaskProcessFinishedCallback);
+
+      testFixtureProvider.executeProcess(processModelSendTask, 'StartEvent_1', correlationId);
+    });
+  });
+
+  it('Should be able to continue a Process with a SendTask, after a ReceiveTask acknowledges receit of the message', async () => {
+    const correlationId = uuid.v4();
+    const endEventToWaitFor = 'EndEvent_1';
+    testFixtureProvider.executeProcess(processModelSendTask, 'StartEvent_1', correlationId);
+
+    await processInstanceHandler.waitForProcessInstanceToReachSuspendedTask(correlationId, processModelSendTask);
+
+    return new Promise((resolve) => {
+
+      const endMessageSendTaskProcess = `/processengine/correlation/${correlationId}/processmodel/${processModelSendTask}/ended`;
+      const sendTaskProcessFinishedCallback = (message) => {
+        const expectedEndEventReached = message.flowNodeId === endEventToWaitFor;
+        if (expectedEndEventReached) {
+          resolve();
+        }
+      };
+
+      eventAggregator.subscribeOnce(endMessageSendTaskProcess, sendTaskProcessFinishedCallback);
+
+      testFixtureProvider.executeProcess(processModelReceiveTask, 'StartEvent_1', correlationId);
+    });
+  });
+
+  it('Should throw an error, if the SendTask does not receive a response within the configured timeframe', async () => {
+    try {
+      await testFixtureProvider.executeProcess(processModelSendTaskAbort);
+    } catch (error) {
+      should(error.message).match(/did not receive a response/i);
+      should(error.code).be.equal(408);
+    }
+  });
+
+});


### PR DESCRIPTION
## Changes

1. Parse `retryIntervalInMs` and `maxRetries` extension properties for SendTasks
2. Implement Retry mechanism for SendTasks
    - The handler will now keep sending the message, until either the maximum number of retries is exceeded or a response was received
    - Retry interval defaults to 500ms
    - Max number of retries defaults to -1 - i.e. `unlimited`

## Issues

Closes #538

PR: #539

## How to test the changes

- Start a ProcessInstance with a SendTask
- See that the SendTask periodically sends its message
- Start a ProcessInstance with a matching ReceiveTask
- See that the SendTask will continue, after the ReceiveTask acknowledges receiving the message